### PR TITLE
W-08: Auth scopes desde OpenAPI (fuente única)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,8 @@ INIT_FUNGIBLE_TOKEN_VAULTS_ON_ACCOUNT_CREATION=true
 # FLOW_WALLET_AUTH_JWT_SECRET=replace-with-strong-secret
 # FLOW_WALLET_AUTH_JWT_ISSUER=artdrop-auth
 # FLOW_WALLET_AUTH_JWT_AUDIENCE=flow-wallet-api
+# Optional override for OpenAPI spec used to derive auth scopes (default: embedded openapi.yml)
+# FLOW_WALLET_OPENAPI_SPEC_PATH=./openapi.yml
 
 # Lightweight mode configuration
 # FLOW_WALLET_LIGHTWEIGHT_MODE=false

--- a/auth/openapi/loader.go
+++ b/auth/openapi/loader.go
@@ -1,0 +1,119 @@
+package openapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const apiVersionPrefix = "/{apiVersion}"
+
+// LoadScopeIndex parses an OpenAPI document and returns a map of route key to required scope.
+// Route keys use the format "METHOD /{apiVersion}/path" matching mux path templates.
+func LoadScopeIndex(spec []byte) (map[string]string, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(spec, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshal openapi spec: %w", err)
+	}
+
+	pathsNode := findMappingValue(&doc, "paths")
+	if pathsNode == nil {
+		return nil, fmt.Errorf("openapi spec missing paths")
+	}
+
+	scopes := make(map[string]string)
+	for i := 0; i < len(pathsNode.Content); i += 2 {
+		openAPIPath := pathsNode.Content[i].Value
+		operationsNode := pathsNode.Content[i+1]
+		for j := 0; j < len(operationsNode.Content); j += 2 {
+			method := strings.ToUpper(operationsNode.Content[j].Value)
+			if !isHTTPMethod(method) {
+				continue
+			}
+
+			requiredScopes := findStringListField(operationsNode.Content[j+1], "x-required-scopes")
+			if len(requiredScopes) == 0 {
+				return nil, fmt.Errorf("operation %s %s missing x-required-scopes", method, openAPIPath)
+			}
+			if len(requiredScopes) != 1 {
+				return nil, fmt.Errorf("operation %s %s must have exactly one x-required-scopes entry", method, openAPIPath)
+			}
+
+			pathTemplate := apiVersionPrefix + openAPIPath
+			key := routeKey(method, pathTemplate)
+			if _, exists := scopes[key]; exists {
+				return nil, fmt.Errorf("duplicate scope key %q", key)
+			}
+			scopes[key] = requiredScopes[0]
+		}
+	}
+
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("openapi spec has no operations with x-required-scopes")
+	}
+
+	return scopes, nil
+}
+
+func routeKey(method, pathTemplate string) string {
+	return method + " " + pathTemplate
+}
+
+func findStringListField(node *yaml.Node, field string) []string {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value != field {
+			continue
+		}
+
+		valueNode := node.Content[i+1]
+		if valueNode.Kind != yaml.SequenceNode {
+			return nil
+		}
+
+		values := make([]string, 0, len(valueNode.Content))
+		for _, item := range valueNode.Content {
+			values = append(values, item.Value)
+		}
+		return values
+	}
+
+	return nil
+}
+
+func findMappingValue(node *yaml.Node, field string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+
+	current := node
+	if current.Kind == yaml.DocumentNode && len(current.Content) > 0 {
+		current = current.Content[0]
+	}
+
+	if current.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(current.Content); i += 2 {
+		if current.Content[i].Value == field {
+			return current.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+func isHTTPMethod(value string) bool {
+	switch value {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch, http.MethodOptions, http.MethodHead:
+		return true
+	default:
+		return false
+	}
+}

--- a/auth/openapi/loader_test.go
+++ b/auth/openapi/loader_test.go
@@ -1,0 +1,68 @@
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadScopeIndex(t *testing.T) {
+	spec := []byte(`
+paths:
+  /health/ready:
+    get:
+      x-required-scopes:
+        - health.read
+  /accounts:
+    get:
+      x-required-scopes:
+        - account.read
+    post:
+      x-required-scopes:
+        - account.create
+`)
+
+	index, err := LoadScopeIndex(spec)
+	if err != nil {
+		t.Fatalf("LoadScopeIndex: %v", err)
+	}
+
+	if index["GET /{apiVersion}/health/ready"] != "health.read" {
+		t.Fatalf("unexpected health scope: %#v", index)
+	}
+	if index["POST /{apiVersion}/accounts"] != "account.create" {
+		t.Fatalf("unexpected create scope: %#v", index)
+	}
+}
+
+func TestLoadScopeIndexRejectsMissingScope(t *testing.T) {
+	spec := []byte(`
+paths:
+  /accounts:
+    get:
+      summary: no scope
+`)
+
+	_, err := LoadScopeIndex(spec)
+	if err == nil || !strings.Contains(err.Error(), "x-required-scopes") {
+		t.Fatalf("expected missing scope error, got %v", err)
+	}
+}
+
+func TestLoadScopeIndexFromRepoOpenAPI(t *testing.T) {
+	specPath := filepath.Join("..", "..", "openapi.yml")
+	spec, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi.yml: %v", err)
+	}
+
+	index, err := LoadScopeIndex(spec)
+	if err != nil {
+		t.Fatalf("LoadScopeIndex: %v", err)
+	}
+
+	if len(index) < 20 {
+		t.Fatalf("expected many scoped operations, got %d", len(index))
+	}
+}

--- a/auth/openapi/rules.go
+++ b/auth/openapi/rules.go
@@ -1,0 +1,82 @@
+package openapi
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/flow-hydraulics/flow-wallet-api/handlers/middleware"
+	"github.com/gorilla/mux"
+)
+
+// CollectRouteKeys returns registered mux route keys as "METHOD pathTemplate".
+func CollectRouteKeys(router *mux.Router) (map[string]struct{}, error) {
+	keys := map[string]struct{}{}
+	err := router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		pathTemplate, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+
+		methods, err := route.GetMethods()
+		if err != nil {
+			return nil
+		}
+
+		for _, method := range methods {
+			keys[routeKey(method, pathTemplate)] = struct{}{}
+		}
+		return nil
+	})
+	return keys, err
+}
+
+// AuthRulesFromRouter builds auth rules for each registered route using scopes from the OpenAPI index.
+func AuthRulesFromRouter(router *mux.Router, index map[string]string) ([]middleware.AuthRule, error) {
+	routeKeys, err := CollectRouteKeys(router)
+	if err != nil {
+		return nil, fmt.Errorf("collect route keys: %w", err)
+	}
+
+	rules := make([]middleware.AuthRule, 0, len(routeKeys))
+	var missing []string
+
+	for key := range routeKeys {
+		scope, ok := index[key]
+		if !ok {
+			missing = append(missing, key)
+			continue
+		}
+
+		method, pathTemplate, err := splitRouteKey(key)
+		if err != nil {
+			return nil, err
+		}
+
+		rules = append(rules, middleware.NewAuthRule(method, pathTemplate, scope))
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("openapi scope missing for routes: %v", missing)
+	}
+
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].Key() < rules[j].Key()
+	})
+
+	return rules, nil
+}
+
+func splitRouteKey(key string) (method string, pathTemplate string, err error) {
+	space := -1
+	for i := 0; i < len(key); i++ {
+		if key[i] == ' ' {
+			space = i
+			break
+		}
+	}
+	if space <= 0 || space >= len(key)-1 {
+		return "", "", fmt.Errorf("invalid route key %q", key)
+	}
+	return key[:space], key[space+1:], nil
+}

--- a/auth/openapi/rules_test.go
+++ b/auth/openapi/rules_test.go
@@ -1,0 +1,44 @@
+package openapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestAuthRulesFromRouter(t *testing.T) {
+	index := map[string]string{
+		"GET /{apiVersion}/health/ready": "health.read",
+		"GET /{apiVersion}/accounts":     "account.read",
+	}
+
+	r := mux.NewRouter()
+	rv := r.PathPrefix("/{apiVersion}").Subrouter()
+	rv.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	rv.HandleFunc("/accounts", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+
+	rules, err := AuthRulesFromRouter(r, index)
+	if err != nil {
+		t.Fatalf("AuthRulesFromRouter: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+}
+
+func TestAuthRulesFromRouterMissingScope(t *testing.T) {
+	index := map[string]string{
+		"GET /{apiVersion}/health/ready": "health.read",
+	}
+
+	r := mux.NewRouter()
+	rv := r.PathPrefix("/{apiVersion}").Subrouter()
+	rv.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+	rv.HandleFunc("/accounts", func(w http.ResponseWriter, r *http.Request) {}).Methods(http.MethodGet)
+
+	_, err := AuthRulesFromRouter(r, index)
+	if err == nil {
+		t.Fatal("expected error for missing openapi scope")
+	}
+}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -120,6 +120,8 @@ type Config struct {
 	AuthJWTSecret   string `env:"AUTH_JWT_SECRET" envDefault:""`
 	AuthJWTIssuer   string `env:"AUTH_JWT_ISSUER" envDefault:""`
 	AuthJWTAudience string `env:"AUTH_JWT_AUDIENCE" envDefault:""`
+	// Optional path to openapi.yml; when empty the embedded spec in the binary is used.
+	AuthOpenAPISpecPath string `env:"OPENAPI_SPEC_PATH" envDefault:""`
 
 	// Duration for which to wait for a transaction seal, if 0 wait indefinitely. Default: 0.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/flow-hydraulics/flow-wallet-api/auth/openapi"
 	"github.com/flow-hydraulics/flow-wallet-api/accounts"
 	"github.com/flow-hydraulics/flow-wallet-api/chain_events"
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
@@ -213,6 +214,19 @@ func runServer(cfg *configs.Config) {
 		},
 	})
 
+	openAPISpecBytes, err := loadOpenAPISpec(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	scopeIndex, err := openapi.LoadScopeIndex(openAPISpecBytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	authRules, err := openapi.AuthRulesFromRouter(r, scopeIndex)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	h := http.TimeoutHandler(r, cfg.ServerRequestTimeout, "request timed out")
 	h = handlers.UseCors(h)
 	h = handlers.UseLogging(h)
@@ -268,7 +282,7 @@ func runServer(cfg *configs.Config) {
 		Secret:   cfg.AuthJWTSecret,
 		Issuer:   cfg.AuthJWTIssuer,
 		Audience: cfg.AuthJWTAudience,
-		Rules:    walletAuthRules(routerOptions),
+		Rules:    authRules,
 	})
 
 	// Server boilerplate
@@ -453,68 +467,12 @@ func buildRouter(opts routeOptions, hs routeHandlers) *mux.Router {
 	return r
 }
 
-func walletAuthRules(opts routeOptions) []handlers.AuthRule {
-	rules := []handlers.AuthRule{
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/debug", "system.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/health/ready", "health.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/health/liveness", "health.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/system/settings", "system.read"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/system/settings", "system.write"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/system/sync-account-key-count", "account.key.sync"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/jobs", "job.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/jobs/{jobId}", "job.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/tokens", "token.read"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/tokens", "token.write"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/tokens/{id_or_name}", "token.read"),
-		handlers.NewAuthRule(http.MethodDelete, "/{apiVersion}/tokens/{id}", "token.write"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/fungible-tokens", "token.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/non-fungible-tokens", "token.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/transactions", "transaction.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/transactions/{transactionId}", "transaction.read"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts", "account.read"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts", "account.create"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}", "account.read"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/watchlist/accounts", "watchlist.write"),
-		handlers.NewAuthRule(http.MethodDelete, "/{apiVersion}/watchlist/accounts/{address}", "watchlist.write"),
-		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/scripts", "script.execute"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/ops/missing-fungible-token-vaults/start", "ops.run"),
-		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/ops/missing-fungible-token-vaults/stats", "ops.read"),
+func loadOpenAPISpec(cfg *configs.Config) ([]byte, error) {
+	if cfg.AuthOpenAPISpecPath != "" {
+		return os.ReadFile(cfg.AuthOpenAPISpecPath)
 	}
-
-	if !opts.DisableRawTransactions {
-		rules = append(rules,
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/sign", "account.sign"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/transactions", "transaction.read"),
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/transactions", "transaction.create"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/transactions/{transactionId}", "transaction.read"),
-		)
+	if len(openAPISpec) == 0 {
+		return nil, fmt.Errorf("embedded openapi spec is empty")
 	}
-
-	if !opts.DisableFungibleTokens {
-		rules = append(rules,
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens", "account.setup"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}", "account.setup"),
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}", "account.setup"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}/withdrawals", "account.transfer"),
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}/withdrawals", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}/withdrawals/{transactionId}", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}/deposits", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/fungible-tokens/{tokenName}/deposits/{transactionId}", "account.transfer"),
-		)
-	}
-
-	if !opts.DisableNonFungibleTokens {
-		rules = append(rules,
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens", "account.setup"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}", "account.setup"),
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}", "account.setup"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}/withdrawals", "account.transfer"),
-			handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}/withdrawals", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}/withdrawals/{transactionId}", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}/deposits", "account.transfer"),
-			handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/accounts/{address}/non-fungible-tokens/{tokenName}/deposits/{transactionId}", "account.transfer"),
-		)
-	}
-
-	return rules
+	return openAPISpec, nil
 }

--- a/main_auth_routes_test.go
+++ b/main_auth_routes_test.go
@@ -3,16 +3,22 @@ package main
 import (
 	"net/http"
 	"os"
-	"sort"
-	"strings"
 	"testing"
 
+	"github.com/flow-hydraulics/flow-wallet-api/auth/openapi"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
-	"github.com/gorilla/mux"
-	"gopkg.in/yaml.v3"
 )
 
 func TestWalletAuthRulesMatchRegisteredRoutes(t *testing.T) {
+	spec, err := os.ReadFile("openapi.yml")
+	if err != nil {
+		t.Fatalf("read openapi.yml: %v", err)
+	}
+	scopeIndex, err := openapi.LoadScopeIndex(spec)
+	if err != nil {
+		t.Fatalf("LoadScopeIndex: %v", err)
+	}
+
 	testCases := []struct {
 		name string
 		opts routeOptions
@@ -44,13 +50,18 @@ func TestWalletAuthRulesMatchRegisteredRoutes(t *testing.T) {
 				WorkerPoolStatus: func() (interface{}, error) { return nil, nil },
 			})
 
-			routeKeys, err := collectRouteKeys(router)
+			rules, err := openapi.AuthRulesFromRouter(router, scopeIndex)
+			if err != nil {
+				t.Fatalf("AuthRulesFromRouter: %v", err)
+			}
+
+			routeKeys, err := openapi.CollectRouteKeys(router)
 			if err != nil {
 				t.Fatalf("collect route keys: %v", err)
 			}
 
-			ruleKeys := make(map[string]struct{}, len(walletAuthRules(tc.opts)))
-			for _, rule := range walletAuthRules(tc.opts) {
+			ruleKeys := make(map[string]struct{}, len(rules))
+			for _, rule := range rules {
 				ruleKeys[rule.Key()] = struct{}{}
 			}
 
@@ -63,27 +74,6 @@ func TestWalletAuthRulesMatchRegisteredRoutes(t *testing.T) {
 	}
 }
 
-func collectRouteKeys(router *mux.Router) (map[string]struct{}, error) {
-	keys := map[string]struct{}{}
-	err := router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
-		pathTemplate, err := route.GetPathTemplate()
-		if err != nil {
-			return nil
-		}
-
-		methods, err := route.GetMethods()
-		if err != nil {
-			return nil
-		}
-
-		for _, method := range methods {
-			keys[method+" "+pathTemplate] = struct{}{}
-		}
-		return nil
-	})
-	return keys, err
-}
-
 func diffKeys(left map[string]struct{}, right map[string]struct{}) []string {
 	var diff []string
 	for key := range left {
@@ -91,7 +81,6 @@ func diffKeys(left map[string]struct{}, right map[string]struct{}) []string {
 			diff = append(diff, key)
 		}
 	}
-	sort.Strings(diff)
 	return diff
 }
 
@@ -102,62 +91,45 @@ func TestWalletAuthRuleMatchesVersionedPath(t *testing.T) {
 	}
 }
 
-func TestWalletAuthRulesMatchOpenAPIRequiredScopes(t *testing.T) {
-	openAPIScopes, err := collectOpenAPIRequiredScopes("openapi.yml")
+func TestOpenAPIScopeIndexCoversFullRouter(t *testing.T) {
+	spec, err := os.ReadFile("openapi.yml")
 	if err != nil {
-		t.Fatalf("collect openapi scopes: %v", err)
+		t.Fatalf("read openapi.yml: %v", err)
+	}
+	scopeIndex, err := openapi.LoadScopeIndex(spec)
+	if err != nil {
+		t.Fatalf("LoadScopeIndex: %v", err)
 	}
 
-	ruleScopes := make(map[string]string, len(walletAuthRules(routeOptions{})))
-	for _, rule := range walletAuthRules(routeOptions{}) {
+	router := buildRouter(routeOptions{}, routeHandlers{
+		System:           handlers.NewSystem(nil),
+		Templates:        handlers.NewTemplates(nil),
+		Jobs:             handlers.NewJobs(nil),
+		Accounts:         handlers.NewAccounts(nil),
+		Transactions:     handlers.NewTransactions(nil),
+		Tokens:           handlers.NewTokens(nil),
+		Ops:              handlers.NewOps(nil),
+		DebugURL:         "debug-url",
+		DebugSHA:         "debug-sha",
+		DebugBuildTime:   "debug-build-time",
+		WorkerPoolStatus: func() (interface{}, error) { return nil, nil },
+	})
+
+	rules, err := openapi.AuthRulesFromRouter(router, scopeIndex)
+	if err != nil {
+		t.Fatalf("AuthRulesFromRouter: %v", err)
+	}
+
+	ruleScopes := make(map[string]string, len(rules))
+	for _, rule := range rules {
 		ruleScopes[rule.Key()] = rule.RequiredScope
 	}
 
-	missing := diffScopeMap(openAPIScopes, ruleScopes)
-	extra := diffScopeMap(ruleScopes, openAPIScopes)
+	missing := diffScopeMap(scopeIndex, ruleScopes)
+	extra := diffScopeMap(ruleScopes, scopeIndex)
 	if len(missing) > 0 || len(extra) > 0 {
-		t.Fatalf("openapi/auth rule scope mismatch\nmissing in code: %v\nextra in code: %v", missing, extra)
+		t.Fatalf("openapi/runtime scope mismatch\nmissing in runtime rules: %v\nextra in runtime rules: %v", missing, extra)
 	}
-}
-
-func collectOpenAPIRequiredScopes(path string) (map[string]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, err
-	}
-
-	pathsNode := findMappingValue(&doc, "paths")
-	if pathsNode == nil {
-		return nil, nil
-	}
-
-	scopes := map[string]string{}
-	for i := 0; i < len(pathsNode.Content); i += 2 {
-		openAPIPath := pathsNode.Content[i].Value
-		operationsNode := pathsNode.Content[i+1]
-		for j := 0; j < len(operationsNode.Content); j += 2 {
-			method := strings.ToUpper(operationsNode.Content[j].Value)
-			if !isHTTPMethod(method) {
-				continue
-			}
-
-			requiredScopes := findStringListField(operationsNode.Content[j+1], "x-required-scopes")
-			if len(requiredScopes) == 0 {
-				continue
-			}
-
-			pathTemplate := "/{apiVersion}" + openAPIPath
-			key := method + " " + pathTemplate
-			scopes[key] = requiredScopes[0]
-		}
-	}
-
-	return scopes, nil
 }
 
 func diffScopeMap(left map[string]string, right map[string]string) []string {
@@ -172,63 +144,5 @@ func diffScopeMap(left map[string]string, right map[string]string) []string {
 			diff = append(diff, key+" ("+leftScope+" != "+rightScope+")")
 		}
 	}
-	sort.Strings(diff)
 	return diff
-}
-
-func findStringListField(node *yaml.Node, field string) []string {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return nil
-	}
-
-	for i := 0; i < len(node.Content); i += 2 {
-		if node.Content[i].Value != field {
-			continue
-		}
-
-		valueNode := node.Content[i+1]
-		if valueNode.Kind != yaml.SequenceNode {
-			return nil
-		}
-
-		values := make([]string, 0, len(valueNode.Content))
-		for _, item := range valueNode.Content {
-			values = append(values, item.Value)
-		}
-		return values
-	}
-
-	return nil
-}
-
-func findMappingValue(node *yaml.Node, field string) *yaml.Node {
-	if node == nil {
-		return nil
-	}
-
-	current := node
-	if current.Kind == yaml.DocumentNode && len(current.Content) > 0 {
-		current = current.Content[0]
-	}
-
-	if current.Kind != yaml.MappingNode {
-		return nil
-	}
-
-	for i := 0; i < len(current.Content); i += 2 {
-		if current.Content[i].Value == field {
-			return current.Content[i+1]
-		}
-	}
-
-	return nil
-}
-
-func isHTTPMethod(value string) bool {
-	switch value {
-	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch, http.MethodOptions, http.MethodHead:
-		return true
-	default:
-		return false
-	}
 }

--- a/openapi_spec.go
+++ b/openapi_spec.go
@@ -1,0 +1,8 @@
+package main
+
+import _ "embed"
+
+// openAPISpec is the embedded Wallet API OpenAPI document (single source for auth scopes).
+//
+//go:embed openapi.yml
+var openAPISpec []byte


### PR DESCRIPTION
## Summary
- Derive Bearer auth scope rules at startup from embedded `openapi.yml` via `auth/openapi`.
- Build rules only for routes registered on the live mux router (feature flags respected).
- Remove manual `walletAuthRules()`; parity tests use OpenAPI as the single source of scope values.
## Test plan
- [x] `go test ./auth/openapi/...`
- [x] `go test ./handlers/middleware/...`
- [x] `go test -run 'Auth|Route|Scope' .` (macOS: `CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"`)
Closes #8