### PR TITLE
W-03: add artist activation and community pool endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ flow-wallet-api
 flow/flowdb
 
 .idea/
+.gocache/
+.gomodcache/

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -15,10 +15,12 @@ const AccountTypeNonCustodial = "non-custodial"
 
 // Account struct represents a storable account.
 type Account struct {
-	Address   string          `json:"address" gorm:"primaryKey"`
-	Keys      []keys.Storable `json:"keys" gorm:"foreignKey:AccountAddress;references:Address;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
-	Type      AccountType     `json:"type" gorm:"default:custodial"`
-	CreatedAt time.Time       `json:"createdAt" `
-	UpdatedAt time.Time       `json:"updatedAt"`
-	DeletedAt gorm.DeletedAt  `json:"-" gorm:"index"`
+	Address              string          `json:"address" gorm:"primaryKey"`
+	Keys                 []keys.Storable `json:"keys" gorm:"foreignKey:AccountAddress;references:Address;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	Type                 AccountType     `json:"type" gorm:"default:custodial"`
+	IsArtist             bool            `json:"isArtist"`
+	CommunityPoolAddress string          `json:"communityPoolAddress,omitempty"`
+	CreatedAt            time.Time       `json:"createdAt" `
+	UpdatedAt            time.Time       `json:"updatedAt"`
+	DeletedAt            gorm.DeletedAt  `json:"-" gorm:"index"`
 }

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
@@ -49,6 +50,7 @@ type ServiceImpl struct {
 	txs           transactions.Service
 	temps         templates.Service
 	txRateLimiter ratelimit.Limiter
+	cpLocks       sync.Map
 }
 
 // NewService initiates a new account service.
@@ -65,7 +67,7 @@ func NewService(
 	var defaultTxRatelimiter = ratelimit.NewUnlimited()
 
 	// TODO(latenssi): safeguard against nil config?
-	svc := &ServiceImpl{cfg, store, km, fc, wp, txs, temps, defaultTxRatelimiter}
+	svc := &ServiceImpl{cfg: cfg, store: store, km: km, fc: fc, wp: wp, txs: txs, temps: temps, txRateLimiter: defaultTxRatelimiter}
 
 	for _, opt := range opts {
 		opt(svc)
@@ -207,30 +209,41 @@ func (s *ServiceImpl) EnableCommunityPool(ctx context.Context, address string) (
 		return Account{}, err
 	}
 
-	account, err := s.store.Account(address)
-	if err != nil {
-		return Account{}, err
-	}
+	return s.withCommunityPoolLock(address, func() (Account, error) {
+		account, err := s.store.Account(address)
+		if err != nil {
+			return Account{}, err
+		}
 
-	if !account.IsArtist {
-		return Account{}, fmt.Errorf("artist account must be activated before enabling community pool")
-	}
+		if !account.IsArtist {
+			return Account{}, fmt.Errorf("artist account must be activated before enabling community pool")
+		}
 
-	if account.CommunityPoolAddress != "" {
+		if account.CommunityPoolAddress != "" {
+			return s.Details(address)
+		}
+
+		poolAccount, _, err := s.createAccount(ctx)
+		if err != nil {
+			return Account{}, err
+		}
+
+		account.CommunityPoolAddress = poolAccount.Address
+		if err := s.store.SaveAccount(&account); err != nil {
+			return Account{}, err
+		}
+
 		return s.Details(address)
-	}
+	})
+}
 
-	poolAccount, _, err := s.createAccount(ctx)
-	if err != nil {
-		return Account{}, err
-	}
+func (s *ServiceImpl) withCommunityPoolLock(address string, fn func() (Account, error)) (Account, error) {
+	locker, _ := s.cpLocks.LoadOrStore(address, &sync.Mutex{})
+	mu := locker.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
 
-	account.CommunityPoolAddress = poolAccount.Address
-	if err := s.store.SaveAccount(&account); err != nil {
-		return Account{}, err
-	}
-
-	return s.Details(address)
+	return fn()
 }
 
 // SyncKeyCount syncs number of keys for given account

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -34,6 +34,8 @@ type Service interface {
 	DeleteNonCustodialAccount(address string) error
 	SyncAccountKeyCount(ctx context.Context, address flow.Address) (*jobs.Job, error)
 	Details(address string) (Account, error)
+	ActivateArtist(address string) (Account, error)
+	EnableCommunityPool(ctx context.Context, address string) (Account, error)
 	InitAdminAccount(ctx context.Context) error
 }
 
@@ -172,6 +174,63 @@ func (s *ServiceImpl) Details(address string) (Account, error) {
 	}
 
 	return account, nil
+}
+
+func (s *ServiceImpl) ActivateArtist(address string) (Account, error) {
+	log.WithFields(log.Fields{"address": address}).Trace("Activate artist")
+
+	address, err := flow_helpers.ValidateAddress(address, s.cfg.ChainID)
+	if err != nil {
+		return Account{}, err
+	}
+
+	account, err := s.store.Account(address)
+	if err != nil {
+		return Account{}, err
+	}
+
+	if !account.IsArtist {
+		account.IsArtist = true
+		if err := s.store.SaveAccount(&account); err != nil {
+			return Account{}, err
+		}
+	}
+
+	return s.Details(address)
+}
+
+func (s *ServiceImpl) EnableCommunityPool(ctx context.Context, address string) (Account, error) {
+	log.WithFields(log.Fields{"address": address}).Trace("Enable community pool")
+
+	address, err := flow_helpers.ValidateAddress(address, s.cfg.ChainID)
+	if err != nil {
+		return Account{}, err
+	}
+
+	account, err := s.store.Account(address)
+	if err != nil {
+		return Account{}, err
+	}
+
+	if !account.IsArtist {
+		return Account{}, fmt.Errorf("artist account must be activated before enabling community pool")
+	}
+
+	if account.CommunityPoolAddress != "" {
+		return s.Details(address)
+	}
+
+	poolAccount, _, err := s.createAccount(ctx)
+	if err != nil {
+		return Account{}, err
+	}
+
+	account.CommunityPoolAddress = poolAccount.Address
+	if err := s.store.SaveAccount(&account); err != nil {
+		return Account{}, err
+	}
+
+	return s.Details(address)
 }
 
 // SyncKeyCount syncs number of keys for given account

--- a/handlers/accounts.go
+++ b/handlers/accounts.go
@@ -47,3 +47,11 @@ func (s *Accounts) SyncAccountKeyCount() http.Handler {
 func (s *Accounts) Details() http.Handler {
 	return http.HandlerFunc(s.DetailsFunc)
 }
+
+func (s *Accounts) ActivateArtist() http.Handler {
+	return http.HandlerFunc(s.ActivateArtistFunc)
+}
+
+func (s *Accounts) EnableCommunityPool() http.Handler {
+	return http.HandlerFunc(s.EnableCommunityPoolFunc)
+}

--- a/handlers/accounts_func.go
+++ b/handlers/accounts_func.go
@@ -72,6 +72,30 @@ func (s *Accounts) DetailsFunc(rw http.ResponseWriter, r *http.Request) {
 	handleJsonResponse(rw, http.StatusOK, res)
 }
 
+func (s *Accounts) ActivateArtistFunc(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	res, err := s.service.ActivateArtist(vars["address"])
+	if err != nil {
+		handleError(rw, r, err)
+		return
+	}
+
+	handleJsonResponse(rw, http.StatusOK, res)
+}
+
+func (s *Accounts) EnableCommunityPoolFunc(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	res, err := s.service.EnableCommunityPool(r.Context(), vars["address"])
+	if err != nil {
+		handleError(rw, r, err)
+		return
+	}
+
+	handleJsonResponse(rw, http.StatusOK, res)
+}
+
 func (s *Accounts) AddNonCustodialAccountFunc(rw http.ResponseWriter, r *http.Request) {
 	err := checkNonEmptyBody(r)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/flow-hydraulics/flow-wallet-api/auth/openapi"
 	"github.com/flow-hydraulics/flow-wallet-api/accounts"
+	"github.com/flow-hydraulics/flow-wallet-api/auth/openapi"
 	"github.com/flow-hydraulics/flow-wallet-api/chain_events"
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
@@ -421,6 +421,8 @@ func buildRouter(opts routeOptions, hs routeHandlers) *mux.Router {
 	rv.Handle("/accounts", hs.Accounts.List()).Methods(http.MethodGet)
 	rv.Handle("/accounts", hs.Accounts.Create()).Methods(http.MethodPost)
 	rv.Handle("/accounts/{address}", hs.Accounts.Details()).Methods(http.MethodGet)
+	rv.Handle("/accounts/{address}/artist-activate", hs.Accounts.ActivateArtist()).Methods(http.MethodPost)
+	rv.Handle("/accounts/{address}/community-pool-enable", hs.Accounts.EnableCommunityPool()).Methods(http.MethodPost)
 
 	if !opts.DisableRawTransactions {
 		rv.Handle("/accounts/{address}/sign", hs.Transactions.Sign()).Methods(http.MethodPost)

--- a/migrations/internal/m20260619/migration.go
+++ b/migrations/internal/m20260619/migration.go
@@ -1,0 +1,35 @@
+package m20260619
+
+import "gorm.io/gorm"
+
+const ID = "20260619"
+
+type Account struct {
+	Address              string `gorm:"primaryKey"`
+	IsArtist             bool
+	CommunityPoolAddress string
+}
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.Migrator().AddColumn(&Account{}, "is_artist"); err != nil {
+		return err
+	}
+
+	if err := tx.Migrator().AddColumn(&Account{}, "community_pool_address"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropColumn(&Account{}, "community_pool_address"); err != nil {
+		return err
+	}
+
+	if err := tx.Migrator().DropColumn(&Account{}, "is_artist"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211221_2"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20220212"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20221001"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20260619"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -71,6 +72,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20221001.ID,
 			Migrate:  m20221001.Migrate,
 			Rollback: m20221001.Rollback,
+		},
+		{
+			ID:       m20260619.ID,
+			Migrate:  m20260619.Migrate,
+			Rollback: m20260619.Rollback,
 		},
 	}
 	return ms

--- a/openapi.yml
+++ b/openapi.yml
@@ -531,6 +531,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/account'
+  '/accounts/{address}/artist-activate':
+    parameters:
+      - $ref: '#/components/parameters/address'
+    post:
+      summary: Activate artist role
+      description: Marks an existing custodial account as an artist account. Does not create a community pool address.
+      operationId: activateArtistAccount
+      x-required-scopes:
+        - account.artist.activate
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+  '/accounts/{address}/community-pool-enable':
+    parameters:
+      - $ref: '#/components/parameters/address'
+    post:
+      summary: Enable community pool
+      description: Creates and links a second custodial Flow address for the artist community pool. This only happens when called explicitly.
+      operationId: enableArtistCommunityPool
+      x-required-scopes:
+        - account.community_pool.enable
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
   '/accounts/{address}/sign':
     post:
       summary: Sign a raw transaction
@@ -1078,6 +1114,12 @@ components:
         type:
           type: string
           example: custodial
+        isArtist:
+          type: boolean
+          example: false
+        communityPoolAddress:
+          type: string
+          example: '0x01cf0e2f2f715450'
         createdAt:
           type: string
           minLength: 1

--- a/tests/w03_account_admin_endpoints_test.go
+++ b/tests/w03_account_admin_endpoints_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers/middleware"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/mux"
+)
+
+func TestW03ArtistActivateAuth(t *testing.T) {
+	secret := "w03-test-secret"
+	rules := []handlers.AuthRule{
+		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/artist-activate", "account.artist.activate"),
+	}
+
+	okHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	router := mux.NewRouter()
+	router.Handle("/v1/accounts/{address}/artist-activate", handlers.UseAuth(okHandler, handlers.AuthOptions{
+		Enabled: true,
+		Secret:  secret,
+		Rules:   rules,
+	})).Methods(http.MethodPost)
+
+	accountURL := "/v1/accounts/0xf8d6e0586b0a20c7/artist-activate"
+
+	t.Run("returns 401 without bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+
+	t.Run("returns 403 with wrong scope", func(t *testing.T) {
+		tok := w03SignedToken(t, secret, "account.read", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected %d, got %d", http.StatusForbidden, rr.Code)
+		}
+	})
+
+	t.Run("returns 200 with valid scope", func(t *testing.T) {
+		tok := w03SignedToken(t, secret, "account.artist.activate", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+}
+
+func TestW03CommunityPoolEnableAuth(t *testing.T) {
+	secret := "w03-test-secret"
+	rules := []handlers.AuthRule{
+		handlers.NewAuthRule(http.MethodPost, "/{apiVersion}/accounts/{address}/community-pool-enable", "account.community_pool.enable"),
+	}
+
+	okHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	router := mux.NewRouter()
+	router.Handle("/v1/accounts/{address}/community-pool-enable", handlers.UseAuth(okHandler, handlers.AuthOptions{
+		Enabled: true,
+		Secret:  secret,
+		Rules:   rules,
+	})).Methods(http.MethodPost)
+
+	accountURL := "/v1/accounts/0xf8d6e0586b0a20c7/community-pool-enable"
+
+	t.Run("returns 401 without bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+
+	t.Run("returns 403 with wrong scope", func(t *testing.T) {
+		tok := w03SignedToken(t, secret, "account.artist.activate", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected %d, got %d", http.StatusForbidden, rr.Code)
+		}
+	})
+
+	t.Run("returns 200 with valid scope", func(t *testing.T) {
+		tok := w03SignedToken(t, secret, "account.community_pool.enable", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodPost, accountURL, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+}
+
+func w03SignedToken(t *testing.T, secret string, scope string, exp time.Time) string {
+	t.Helper()
+	claims := middleware.AuthClaims{
+		Scope: scope,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(exp),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}

--- a/w03_account_endpoints_test.go
+++ b/w03_account_endpoints_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/tests/test"
+)
+
+func TestW03ArtistActivationAndCommunityPoolFlow(t *testing.T) {
+	cfg := test.LoadConfig(t)
+	app := test.GetServices(t, cfg)
+	svc := app.GetAccounts()
+
+	_, account, err := svc.Create(context.Background(), true)
+	fatal(t, err)
+
+	activated, err := svc.ActivateArtist(account.Address)
+	fatal(t, err)
+
+	if !activated.IsArtist {
+		t.Fatal("expected artist account to be activated")
+	}
+
+	if activated.CommunityPoolAddress != "" {
+		t.Fatal("artist activation should not create a community pool address")
+	}
+
+	pooled, err := svc.EnableCommunityPool(context.Background(), account.Address)
+	fatal(t, err)
+
+	if !pooled.IsArtist {
+		t.Fatal("expected account to remain marked as artist")
+	}
+
+	if pooled.CommunityPoolAddress == "" {
+		t.Fatal("expected community pool address to be created")
+	}
+
+	if pooled.CommunityPoolAddress == pooled.Address {
+		t.Fatal("expected community pool address to differ from artist address")
+	}
+
+	poolAccount, err := svc.Details(pooled.CommunityPoolAddress)
+	fatal(t, err)
+
+	if poolAccount.Address != pooled.CommunityPoolAddress {
+		t.Fatalf("expected community pool account %s, got %s", pooled.CommunityPoolAddress, poolAccount.Address)
+	}
+
+	if poolAccount.IsArtist {
+		t.Fatal("expected community pool account to remain a regular custodial account")
+	}
+
+	pooledAgain, err := svc.EnableCommunityPool(context.Background(), account.Address)
+	fatal(t, err)
+
+	if pooledAgain.CommunityPoolAddress != pooled.CommunityPoolAddress {
+		t.Fatal("expected community pool enable to be idempotent once address exists")
+	}
+}
+
+func TestW03CommunityPoolRequiresArtistActivation(t *testing.T) {
+	cfg := test.LoadConfig(t)
+	app := test.GetServices(t, cfg)
+	svc := app.GetAccounts()
+
+	_, account, err := svc.Create(context.Background(), true)
+	fatal(t, err)
+
+	_, err = svc.EnableCommunityPool(context.Background(), account.Address)
+	if err == nil {
+		t.Fatal("expected enabling community pool without artist activation to fail")
+	}
+
+	if !strings.Contains(err.Error(), "artist account must be activated") {
+		t.Fatalf("expected artist activation error, got %v", err)
+	}
+}

--- a/w03_account_endpoints_test.go
+++ b/w03_account_endpoints_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
 	"github.com/flow-hydraulics/flow-wallet-api/tests/test"
 )
 
@@ -76,5 +79,90 @@ func TestW03CommunityPoolRequiresArtistActivation(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "artist account must be activated") {
 		t.Fatalf("expected artist activation error, got %v", err)
+	}
+}
+
+func TestW03ArtistActivationHandler(t *testing.T) {
+	cfg := test.LoadConfig(t)
+	app := test.GetServices(t, cfg)
+	svc := app.GetAccounts()
+	handler := handlers.NewAccounts(svc)
+
+	_, account, err := svc.Create(context.Background(), true)
+	fatal(t, err)
+
+	router := buildRouter(routeOptions{}, routeHandlers{
+		System:           handlers.NewSystem(app.GetSystem()),
+		Templates:        handlers.NewTemplates(app.GetTemplates()),
+		Jobs:             handlers.NewJobs(app.GetJobs()),
+		Accounts:         handler,
+		Transactions:     handlers.NewTransactions(app.GetTransactions()),
+		Tokens:           handlers.NewTokens(app.GetTokens()),
+		Ops:              handlers.NewOps(app.GetOps()),
+		DebugURL:         "debug-url",
+		DebugSHA:         "debug-sha",
+		DebugBuildTime:   "debug-build-time",
+		WorkerPoolStatus: func() (interface{}, error) { return nil, nil },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/"+account.Address+"/artist-activate", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	refreshed, err := svc.Details(account.Address)
+	fatal(t, err)
+
+	if !refreshed.IsArtist {
+		t.Fatal("expected artist flag to be persisted after handler call")
+	}
+
+	if refreshed.CommunityPoolAddress != "" {
+		t.Fatal("artist activation handler should not create community pool address")
+	}
+}
+
+func TestW03CommunityPoolEnableHandler(t *testing.T) {
+	cfg := test.LoadConfig(t)
+	app := test.GetServices(t, cfg)
+	svc := app.GetAccounts()
+	handler := handlers.NewAccounts(svc)
+
+	_, account, err := svc.Create(context.Background(), true)
+	fatal(t, err)
+
+	_, err = svc.ActivateArtist(account.Address)
+	fatal(t, err)
+
+	router := buildRouter(routeOptions{}, routeHandlers{
+		System:           handlers.NewSystem(app.GetSystem()),
+		Templates:        handlers.NewTemplates(app.GetTemplates()),
+		Jobs:             handlers.NewJobs(app.GetJobs()),
+		Accounts:         handler,
+		Transactions:     handlers.NewTransactions(app.GetTransactions()),
+		Tokens:           handlers.NewTokens(app.GetTokens()),
+		Ops:              handlers.NewOps(app.GetOps()),
+		DebugURL:         "debug-url",
+		DebugSHA:         "debug-sha",
+		DebugBuildTime:   "debug-build-time",
+		WorkerPoolStatus: func() (interface{}, error) { return nil, nil },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/"+account.Address+"/community-pool-enable", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	refreshed, err := svc.Details(account.Address)
+	fatal(t, err)
+
+	if refreshed.CommunityPoolAddress == "" {
+		t.Fatal("expected community pool address to be persisted after handler call")
 	}
 }


### PR DESCRIPTION
## Summary

Implements W-03 artist account enablement endpoints for the Wallet API:

- `POST /v1/accounts/{address}/artist-activate` marks an existing custodial account as an artist account
- `POST /v1/accounts/{address}/community-pool-enable` creates and links a second custodial Flow address for the artist community pool
- Community pool creation is explicit opt-in and does not happen during artist activation
- Added auth scope coverage and route documentation in `openapi.yml`

## Changes

- Added account fields:
  - `isArtist`
  - `communityPoolAddress`
- Added migration for the new account columns
- Added service methods:
  - `ActivateArtist`
  - `EnableCommunityPool`
- Added HTTP handlers and routes for both endpoints
- Added OpenAPI scope definitions:
  - `account.artist.activate`
  - `account.community_pool.enable`
- Added tests for:
  - auth 401/403 behavior
  - service flow
  - real HTTP handler flow
- Added per-account in-process locking around community pool enablement to avoid duplicate pool creation from concurrent requests in the same service instance

## Validation

### Local
- `go test -run 'TestW03|Auth|Route|Scope' . ./tests/` ✅
- `go build ./...` ✅

## Notes

- `artist-activate` only marks the account and does not create a second address
- `community-pool-enable` creates the linked second address only when explicitly called
- The concurrency guard for community pool creation is currently process-local; distributed locking would be a later hardening step if the service runs with multiple writers

Closes #3