### PR TITLE
feat(artdrop): add plugin skeleton with typed stubs and CDC files

### DIFF
--- a/artdrop/cdc/activate_chip_and_settle.cdc
+++ b/artdrop/cdc/activate_chip_and_settle.cdc
@@ -1,0 +1,37 @@
+/// activate_chip_and_settle.cdc — E-01 (D6): atomic chip activation + escrow settlement + certificate transfer.
+///
+/// The signer is the buyer (chip tapper). Requires:
+/// - Escrow in Pending status, owned by the signer (caller == buyer)
+/// - Valid challenge + signature against the registered chipPubKey
+/// - certificateId currently owned by certificateOwner
+///
+/// Atomic: signature verify + protocol transfer of the NFT to the buyer +
+/// markEscrowSettled happen together or the whole transaction reverts.
+
+import "ArtDropCore"
+import "EscrowModule"
+
+transaction(
+    logicOwner: Address,
+    escrowId: UInt64,
+    challenge: String,
+    signature: [UInt8],
+    certificateId: UInt64,
+    certificateOwner: Address
+) {
+    prepare(signer: &Account) {
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("activate_chip_and_settle: EscrowModule capability missing")
+
+        escrowLogic.activateChipAndSettle(
+            escrowId: escrowId,
+            challenge: challenge,
+            signature: signature,
+            activator: signer.address,
+            certificateId: certificateId,
+            certificateOwner: certificateOwner
+        )
+    }
+}

--- a/artdrop/cdc/cancel_escrow.cdc
+++ b/artdrop/cdc/cancel_escrow.cdc
@@ -1,0 +1,29 @@
+/// cancel_escrow.cdc — Buyer cancela escrow antes de unlockAt.
+///
+/// El buyer cancela el escrow antes de que expire el timelock.
+/// El vault se devuelve al buyer.
+
+import "FungibleToken"
+import "EscrowModule"
+
+transaction(
+    logicOwner: Address,
+    escrowId: UInt64
+) {
+    prepare(signer: auth(BorrowValue) &Account) {
+        let vault = signer.storage.borrow<&{FungibleToken.Receiver}>(
+            from: /storage/flowTokenVault
+        ) ?? panic("cancel_escrow: flowTokenVault not found")
+
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("cancel_escrow: EscrowModule capability missing")
+
+        escrowLogic.cancel(
+            escrowId: escrowId,
+            buyerVault: vault,
+            buyer: signer.address
+        )
+    }
+}

--- a/artdrop/cdc/create_escrow.cdc
+++ b/artdrop/cdc/create_escrow.cdc
@@ -1,0 +1,49 @@
+/// create_escrow.cdc — Protocol crea un escrow en Pending status.
+///
+/// El buyer paga 100% off-chain (Stripe). El protocolo toma el 5%,
+/// lo convierte a FLOW, y firma esta transacción para crear el escrow.
+/// El seller recibe el Certificate cuando el buyer active el chip (D6).
+
+import "FungibleToken"
+import "ArtDropCore"
+import "EscrowModule"
+
+transaction(
+    logicOwner: Address,
+    buyer: Address,
+    seller: Address,
+    editionId: UInt64,
+    chipId: String,
+    chipPubKey: [UInt8],
+    unlockAt: UFix64,
+    nonce: UInt64,
+    amount: UFix64,
+    vaultIdentifier: String
+) {
+    prepare(signer: auth(BorrowValue, FungibleToken.Withdraw) &Account) {
+        let vaultPath = StoragePath(identifier: vaultIdentifier)!
+        let vault = signer.storage.borrow<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(
+            from: vaultPath
+        ) ?? panic("create_escrow: vault not found at path")
+
+        let payment <- vault.withdraw(amount: amount)
+
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("create_escrow: EscrowModule capability missing")
+
+        let escrowId = escrowLogic.createEscrow(
+            buyer: buyer,
+            seller: seller,
+            editionId: editionId,
+            chipId: chipId,
+            chipPubKey: chipPubKey,
+            unlockAt: unlockAt,
+            nonce: nonce,
+            payment: <-payment
+        )
+
+        log("Escrow created with id: ".concat(escrowId.toString()))
+    }
+}

--- a/artdrop/cdc/get_certificate_ids.cdc
+++ b/artdrop/cdc/get_certificate_ids.cdc
@@ -1,0 +1,10 @@
+import "ArtDropCore"
+import "NonFungibleToken"
+
+access(all) fun main(addr: Address): [UInt64] {
+    let collection = getAccount(addr).capabilities
+        .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
+    if collection == nil { return [] }
+    let ids = collection!.getIDs()
+    return ids
+}

--- a/artdrop/cdc/get_escrow_summary.cdc
+++ b/artdrop/cdc/get_escrow_summary.cdc
@@ -1,0 +1,9 @@
+import "EscrowModule"
+
+access(all) fun main(escrowId: UInt64): UInt8 {
+    let acct = getAccount(0xf73e0e516e336e9f)
+    let cap = acct.capabilities.get<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+    let ref = cap.borrow()
+        ?? panic("Could not borrow EscrowLogic reference")
+    return ref.borrowEscrowReadOnly(escrowId: escrowId).status
+}

--- a/artdrop/cdc/refund_escrow.cdc
+++ b/artdrop/cdc/refund_escrow.cdc
@@ -1,0 +1,29 @@
+/// refund_escrow.cdc — Buyer refund despues de unlockAt.
+///
+/// El buyer recupera el vault del escrow cuando el timelock expiro.
+/// Solo funciona si unlockAt ya paso y el escrow sigue en Pending.
+
+import "FungibleToken"
+import "EscrowModule"
+
+transaction(
+    logicOwner: Address,
+    escrowId: UInt64
+) {
+    prepare(signer: auth(BorrowValue) &Account) {
+        let vault = signer.storage.borrow<&{FungibleToken.Receiver}>(
+            from: /storage/flowTokenVault
+        ) ?? panic("refund_escrow: flowTokenVault not found")
+
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("refund_escrow: EscrowModule capability missing")
+
+        escrowLogic.refund(
+            escrowId: escrowId,
+            buyerVault: vault,
+            caller: signer.address
+        )
+    }
+}

--- a/artdrop/cdc/register_provider.cdc
+++ b/artdrop/cdc/register_provider.cdc
@@ -1,0 +1,21 @@
+/// register_provider.cdc — Register a provider capability for protocol transfer.
+///
+/// Registers a Capability<auth(NonFungibleToken.Withdraw) &ArtDropCore.Collection>
+/// in ArtDropCore so that ProtocolAdmin can transfer certificates FROM this account
+/// via protocol_transfer.cdc.
+///
+/// Required before ProtocolAdmin can move a Certificate out of this account.
+/// One-time setup per account.
+
+import "ArtDropCore"
+import "NonFungibleToken"
+
+transaction {
+    prepare(signer: auth(IssueStorageCapabilityController) &Account) {
+        let cap = signer.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &ArtDropCore.Collection>(
+            ArtDropCore.CertCollectionStoragePath
+        )
+
+        ArtDropCore.registerProviderCap(cap: cap, address: signer.address)
+    }
+}

--- a/artdrop/cdc/release_escrow.cdc
+++ b/artdrop/cdc/release_escrow.cdc
@@ -1,0 +1,39 @@
+/// release_escrow.cdc — Buyer releases escrow vault al treasury del protocolo.
+///
+/// Despues de activate_chip_and_settle (D6), el escrow queda Settled pero el
+/// vault queda lockeado. El buyer llama esto para distribuir el vault de vuelta
+/// al protocolo y marcar el escrow como Released.
+
+import "FungibleToken"
+import "EscrowModule"
+import "PaymentModule"
+
+transaction(
+    logicOwner: Address,
+    escrowId: UInt64
+) {
+    prepare(signer: &Account) {
+        let treasury = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{FungibleToken.Receiver}>(EscrowModule.artDropVaultPublicPath)
+            ?? panic("release_escrow: treasury receiver missing")
+
+        let ctx = PaymentModule.DistributionContext(
+            artistVault: treasury,
+            platformVault: treasury,
+            yieldVault: treasury,
+            communityVault: nil
+        )
+
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("release_escrow: EscrowModule capability missing")
+
+        escrowLogic.releaseEscrow(
+            escrowId: escrowId,
+            ctx: ctx,
+            releaser: signer.address
+        )
+    }
+}

--- a/artdrop/cdc/setup_collection.cdc
+++ b/artdrop/cdc/setup_collection.cdc
@@ -1,0 +1,22 @@
+/// setup_collection.cdc — Initialize a CertificateNFT Collection for the signer.
+/// Creates the collection in storage and publishes the public capability if not already present.
+
+import "ArtDropCore"
+
+transaction {
+    prepare(signer: auth(SaveValue, IssueStorageCapabilityController, PublishCapability, BorrowValue) &Account) {
+        if signer.storage.borrow<&ArtDropCore.Collection>(from: ArtDropCore.CertCollectionStoragePath) == nil {
+            signer.storage.save(
+                <-ArtDropCore.createEmptyCollection(nftType: Type<@ArtDropCore.Certificate>()),
+                to: ArtDropCore.CertCollectionStoragePath
+            )
+        }
+
+        if signer.capabilities.borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath) == nil {
+            let cap = signer.capabilities.storage.issue<&ArtDropCore.Collection>(
+                ArtDropCore.CertCollectionStoragePath
+            )
+            signer.capabilities.publish(cap, at: ArtDropCore.CertCollectionPublicPath)
+        }
+    }
+}

--- a/artdrop/config.go
+++ b/artdrop/config.go
@@ -1,0 +1,7 @@
+package artdrop
+
+// Config holds artdrop-specific configuration settings.
+type Config struct {
+	LogicOwner          string
+	EscrowModuleAddress string
+}

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -1,0 +1,79 @@
+package artdrop
+
+import (
+	"net/http"
+)
+
+// Handler exposes HTTP endpoints for the artdrop plugin.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a handler backed by the given artdrop service.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+func (h *Handler) Setup() http.Handler {
+	return http.HandlerFunc(h.SetupFunc)
+}
+
+func (h *Handler) SetupFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) CreateEscrow() http.Handler {
+	return http.HandlerFunc(h.CreateEscrowFunc)
+}
+
+func (h *Handler) CreateEscrowFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) ActivateChip() http.Handler {
+	return http.HandlerFunc(h.ActivateChipFunc)
+}
+
+func (h *Handler) ActivateChipFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) Release() http.Handler {
+	return http.HandlerFunc(h.ReleaseFunc)
+}
+
+func (h *Handler) ReleaseFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) Cancel() http.Handler {
+	return http.HandlerFunc(h.CancelFunc)
+}
+
+func (h *Handler) CancelFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) Refund() http.Handler {
+	return http.HandlerFunc(h.RefundFunc)
+}
+
+func (h *Handler) RefundFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) ListCertificates() http.Handler {
+	return http.HandlerFunc(h.ListCertificatesFunc)
+}
+
+func (h *Handler) ListCertificatesFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) GetEscrow() http.Handler {
+	return http.HandlerFunc(h.GetEscrowFunc)
+}
+
+func (h *Handler) GetEscrowFunc(rw http.ResponseWriter, r *http.Request) {
+	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+}

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -1,0 +1,37 @@
+package artdrop
+
+import (
+	"net/http"
+
+	"github.com/flow-hydraulics/flow-wallet-api/plugins"
+	"github.com/gorilla/mux"
+)
+
+// Plugin is the artdrop plugin entry point.
+type Plugin struct {
+	svc *Service
+}
+
+// NewPlugin creates the artdrop plugin using the shared application dependencies.
+func NewPlugin(deps plugins.PluginDeps) plugins.Plugin {
+	return &Plugin{svc: NewService(deps)}
+}
+
+// Name returns the plugin name.
+func (p *Plugin) Name() string {
+	return "artdrop"
+}
+
+// RegisterRoutes adds the artdrop plugin routes to the API router.
+func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
+	h := NewHandler(p.svc)
+
+	router.Handle("/accounts/{address}/artdrop/setup", h.Setup()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows", h.CreateEscrow()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate", h.ActivateChip()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/release", h.Release()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/cancel", h.Cancel()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/refund", h.Refund()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/certificates", h.ListCertificates()).Methods(http.MethodGet)
+	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}", h.GetEscrow()).Methods(http.MethodGet)
+}

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -1,0 +1,60 @@
+package artdrop
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/plugins"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+)
+
+// Service implements the artdrop plugin business logic.
+type Service struct {
+	deps plugins.PluginDeps
+}
+
+// NewService creates a new artdrop service using the shared plugin dependencies.
+func NewService(deps plugins.PluginDeps) *Service {
+	return &Service{deps: deps}
+}
+
+// Setup prepares an account to use the artdrop contract suite.
+func (s *Service) Setup(ctx context.Context, sync bool, address string) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// CreateEscrow starts a new escrow between a buyer and a seller.
+func (s *Service) CreateEscrow(ctx context.Context, sync bool, address string, req CreateEscrowRequest) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// ActivateChip validates a chip signature and settles the escrow.
+func (s *Service) ActivateChip(ctx context.Context, sync bool, address string, escrowId uint64, req ActivateChipRequest) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// Release releases the escrowed funds to the seller.
+func (s *Service) Release(ctx context.Context, sync bool, address string, escrowId uint64, req EscrowActionRequest) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// Cancel cancels the escrow and returns the funds to the buyer.
+func (s *Service) Cancel(ctx context.Context, sync bool, address string, escrowId uint64, req EscrowActionRequest) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// Refund refunds the escrowed funds.
+func (s *Service) Refund(ctx context.Context, sync bool, address string, escrowId uint64, req EscrowActionRequest) (*jobs.Job, *transactions.Transaction, error) {
+	return nil, nil, errors.New("artdrop: not implemented")
+}
+
+// ListCertificates returns the certificates owned by the given address.
+func (s *Service) ListCertificates(ctx context.Context, address string) ([]CertificateInfo, error) {
+	return nil, errors.New("artdrop: not implemented")
+}
+
+// GetEscrow returns a summary of the requested escrow.
+func (s *Service) GetEscrow(ctx context.Context, escrowId uint64) (*EscrowSummary, error) {
+	return nil, errors.New("artdrop: not implemented")
+}

--- a/artdrop/types.go
+++ b/artdrop/types.go
@@ -1,0 +1,56 @@
+package artdrop
+
+import "github.com/flow-hydraulics/flow-wallet-api/transactions"
+
+// Transaction types used by the artdrop plugin.
+const (
+	TxTypeSetup        transactions.Type = "ArtdropSetup"
+	TxTypeCreateEscrow transactions.Type = "ArtdropCreateEscrow"
+	TxTypeActivateChip transactions.Type = "ArtdropActivateChip"
+	TxTypeRelease      transactions.Type = "ArtdropRelease"
+	TxTypeCancel       transactions.Type = "ArtdropCancel"
+	TxTypeRefund       transactions.Type = "ArtdropRefund"
+)
+
+// CreateEscrowRequest contains the parameters needed to create a new escrow.
+type CreateEscrowRequest struct {
+	LogicOwner      string  `json:"logic_owner"`
+	Buyer           string  `json:"buyer"`
+	Seller          string  `json:"seller"`
+	EditionId       uint64  `json:"edition_id"`
+	ChipId          string  `json:"chip_id"`
+	ChipPubKey      []byte  `json:"chip_pub_key"`
+	UnlockAt        float64 `json:"unlock_at"`
+	Nonce           uint64  `json:"nonce"`
+	VaultIdentifier string  `json:"vault_identifier"`
+}
+
+// ActivateChipRequest contains the parameters needed to activate a chip and settle an escrow.
+type ActivateChipRequest struct {
+	LogicOwner       string `json:"logic_owner"`
+	EscrowId         uint64 `json:"escrow_id"`
+	Challenge        string `json:"challenge"`
+	Signature        []byte `json:"signature"`
+	CertificateId    uint64 `json:"certificate_id"`
+	CertificateOwner string `json:"certificate_owner"`
+}
+
+// EscrowActionRequest is a reusable payload for release, cancel and refund actions.
+type EscrowActionRequest struct {
+	LogicOwner string `json:"logic_owner"`
+}
+
+// CertificateInfo represents a single certificate returned by the list endpoint.
+type CertificateInfo struct {
+	Id              uint64  `json:"id"`
+	EditionId       uint64  `json:"edition_id"`
+	Serial          uint64  `json:"serial"`
+	IsRevealed      bool    `json:"is_revealed"`
+	FinalMultiplier *string `json:"final_multiplier,omitempty"`
+}
+
+// EscrowSummary is the minimal representation of an escrow returned by the get endpoint.
+type EscrowSummary struct {
+	Id     uint64 `json:"id"`
+	Status uint8  `json:"status"`
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/auth/openapi"
 	"github.com/flow-hydraulics/flow-wallet-api/chain_events"
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop"
 	"github.com/flow-hydraulics/flow-wallet-api/example"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
@@ -408,6 +409,7 @@ type routeHandlers struct {
 func registerPlugins(cfg *configs.Config, deps plugins.PluginDeps) []plugins.Plugin {
 	return []plugins.Plugin{
 		example.NewPlugin(deps),
+		artdrop.NewPlugin(deps),
 	}
 }
 


### PR DESCRIPTION
Plugin esqueleto para ArtDrop protocol.

- artdrop/plugin.go con 8 rutas registradas via RegisterRoutes
- artdrop/types.go con request/response structs y TxType constants
- artdrop/service.go con stubs (devuelven "not implemented")
- artdrop/handler.go con stubs (devuelven 501)
- artdrop/config.go con campos LogicOwner y EscrowModuleAddress
- artdrop/cdc/ con 9 transacciones Cadence del protocolo
- main.go registra artdrop.NewPlugin en registerPlugins()