### PR TITLE
W-09: implement ArtDrop account setup

### DIFF
--- a/accounts/service.go
+++ b/accounts/service.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	stdErrors "errors"
 	"fmt"
-	"strings"
 	"net"
 	"net/http"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +42,7 @@ type Service interface {
 	ReconcileAccountWithChain(ctx context.Context, address string) (Account, error)
 	RequireCustodialForSigning(address string) error
 	SyncAccountKeyCount(ctx context.Context, address flow.Address) (*jobs.Job, error)
+	RotateKey(ctx context.Context, sync bool, address string) (*jobs.Job, *RotateKeyResult, error)
 	Details(address string) (Account, error)
 	ActivateArtist(address string) (Account, error)
 	EnableCommunityPool(ctx context.Context, address string) (Account, error)
@@ -88,6 +89,7 @@ func NewService(
 	// Register asynchronous job executors
 	wp.RegisterExecutor(AccountCreateJobType, svc.executeAccountCreateJob)
 	wp.RegisterExecutor(SyncAccountKeyCountJobType, svc.executeSyncAccountKeyCountJob)
+	wp.RegisterExecutor(RotateKeyJobType, svc.executeRotateKeyJob)
 
 	return svc
 }

--- a/accounts/service_graduate_test.go
+++ b/accounts/service_graduate_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/keys"
 	"github.com/flow-hydraulics/flow-wallet-api/transactions"
-"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -215,6 +215,14 @@ func (s *graduateStore) SaveAccount(a *Account) error {
 	return s.saveErr
 }
 
+func (s *graduateStore) InsertKey(k *keys.Storable) error { panic("not used") }
+
+func (s *graduateStore) ArchiveKey(id int) error { panic("not used") }
+
+func (s *graduateStore) RotateKeyState(oldKeyID int, newKey *keys.Storable) error {
+	panic("not used")
+}
+
 func (s *graduateStore) HardDeleteAccount(a *Account) error { return nil }
 
 type graduateTxService struct {
@@ -331,7 +339,7 @@ type testTransientError struct {
 	msg string
 }
 
-func (e *testTransientError) Error() string { return e.msg }
+func (e *testTransientError) Error() string   { return e.msg }
 func (e *testTransientError) Timeout() bool   { return true }
 func (e *testTransientError) Temporary() bool { return true }
 

--- a/accounts/store.go
+++ b/accounts/store.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
+	"github.com/flow-hydraulics/flow-wallet-api/keys"
 )
 
 // Store manages data regarding accounts.
@@ -17,6 +18,15 @@ type Store interface {
 
 	// Update an existing account.
 	SaveAccount(a *Account) error
+
+	// Insert a new account key.
+	InsertKey(k *keys.Storable) error
+
+	// ArchiveKey soft-deletes a key row for audit retention.
+	ArchiveKey(id int) error
+
+	// RotateKeyState atomically archives the old key row and inserts the new key row.
+	RotateKeyState(oldKeyID int, newKey *keys.Storable) error
 
 	// Permanently delete an account, despite of `DeletedAt` field.
 	HardDeleteAccount(a *Account) error

--- a/accounts/store_gorm.go
+++ b/accounts/store_gorm.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
+	"github.com/flow-hydraulics/flow-wallet-api/keys"
 	"gorm.io/gorm"
 )
 
@@ -33,6 +34,26 @@ func (s *GormStore) InsertAccount(a *Account) error {
 
 func (s *GormStore) SaveAccount(a *Account) error {
 	return s.db.Save(&a).Error
+}
+
+func (s *GormStore) InsertKey(k *keys.Storable) error {
+	return s.db.Create(k).Error
+}
+
+func (s *GormStore) ArchiveKey(id int) error {
+	return s.db.Delete(&keys.Storable{}, id).Error
+}
+
+func (s *GormStore) RotateKeyState(oldKeyID int, newKey *keys.Storable) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&keys.Storable{}, oldKeyID).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(newKey).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (s *GormStore) HardDeleteAccount(a *Account) error {

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -77,7 +77,21 @@ func (h *Handler) Setup() http.Handler {
 }
 
 func (h *Handler) SetupFunc(rw http.ResponseWriter, r *http.Request) {
-	http.Error(rw, "artdrop: not implemented", http.StatusNotImplemented)
+	sync := r.FormValue(handlers.SyncQueryParameter) != ""
+	job, transaction, err := h.svc.Setup(r.Context(), sync, mux.Vars(r)["address"])
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	var res interface{}
+	if sync {
+		res = transaction.ToJSONResponse()
+	} else {
+		res = job.ToJSONResponse()
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusCreated, res)
 }
 
 func (h *Handler) CreateEscrow() http.Handler {

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -2,6 +2,7 @@ package artdrop
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,12 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 )
+
+//go:embed cdc/setup_collection.cdc
+var setupCollectionCDC string
+
+//go:embed cdc/register_provider.cdc
+var registerProviderCDC string
 
 // Service implements the artdrop plugin business logic.
 type Service struct {
@@ -61,7 +68,21 @@ func (s *Service) Transfer(ctx context.Context, sync bool, address string, req T
 
 // Setup prepares an account to use the artdrop contract suite.
 func (s *Service) Setup(ctx context.Context, sync bool, address string) (*jobs.Job, *transactions.Transaction, error) {
-	return nil, nil, errors.New("artdrop: not implemented")
+	address, err := flow_helpers.ValidateAddress(address, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, _, err := s.deps.Transactions.Create(ctx, true, address, setupCollectionCDC, nil, TxTypeSetup); err != nil {
+		return nil, nil, fmt.Errorf("setup artdrop collection: %w", err)
+	}
+
+	job, tx, err := s.deps.Transactions.Create(ctx, sync, address, registerProviderCDC, nil, TxTypeSetup)
+	if err != nil {
+		return nil, nil, fmt.Errorf("register artdrop provider: %w", err)
+	}
+
+	return job, tx, nil
 }
 
 // CreateEscrow starts a new escrow between a buyer and a seller.

--- a/artdrop/service_test.go
+++ b/artdrop/service_test.go
@@ -1,0 +1,192 @@
+package artdrop
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/plugins"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"github.com/gorilla/mux"
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk"
+)
+
+func TestServiceSetupCreatesCollectionThenRegistersProvider(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	_, tx, err := svc.Setup(context.Background(), true, "0xf8d6e0586b0a20c7")
+	if err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+
+	if tx == nil {
+		t.Fatal("expected returned transaction")
+	}
+
+	if len(txSvc.calls) != 2 {
+		t.Fatalf("expected 2 transactions, got %d", len(txSvc.calls))
+	}
+
+	if !strings.Contains(txSvc.calls[0].code, "createEmptyCollection") {
+		t.Fatalf("first transaction should setup collection, got code: %s", txSvc.calls[0].code)
+	}
+	if !strings.Contains(txSvc.calls[1].code, "registerProviderCap") {
+		t.Fatalf("second transaction should register provider, got code: %s", txSvc.calls[1].code)
+	}
+
+	for _, call := range txSvc.calls {
+		if call.proposerAddress != "0xf8d6e0586b0a20c7" {
+			t.Fatalf("expected normalized proposer address, got %q", call.proposerAddress)
+		}
+		if call.txType != TxTypeSetup {
+			t.Fatalf("expected transaction type %q, got %q", TxTypeSetup, call.txType)
+		}
+	}
+
+	if !txSvc.calls[0].sync || !txSvc.calls[1].sync {
+		t.Fatal("expected sync setup to execute both transactions synchronously")
+	}
+}
+
+func TestServiceSetupAsyncRunsCollectionBeforeSchedulingProvider(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	job, tx, err := svc.Setup(context.Background(), false, "0xf8d6e0586b0a20c7")
+	if err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+	if job == nil || tx == nil {
+		t.Fatal("expected async setup to return provider job and transaction")
+	}
+
+	if len(txSvc.calls) != 2 {
+		t.Fatalf("expected 2 transactions, got %d", len(txSvc.calls))
+	}
+	if !txSvc.calls[0].sync {
+		t.Fatal("expected collection setup to run synchronously before provider registration")
+	}
+	if txSvc.calls[1].sync {
+		t.Fatal("expected provider registration to honor async request")
+	}
+}
+
+func TestServiceSetupStopsWhenCollectionSetupFails(t *testing.T) {
+	txSvc := &setupTxService{err: errors.New("collection failed")}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	_, _, err := svc.Setup(context.Background(), true, "0xf8d6e0586b0a20c7")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected only collection transaction, got %d calls", len(txSvc.calls))
+	}
+}
+
+func TestSetupFuncReturnsCreatedTransaction(t *testing.T) {
+	txSvc := &setupTxService{}
+	h := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/0xf8d6e0586b0a20c7/artdrop/setup?sync=true", nil)
+	req = mux.SetURLVars(req, map[string]string{"address": "0xf8d6e0586b0a20c7"})
+	rr := httptest.NewRecorder()
+
+	h.SetupFunc(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"transactionType":"ArtdropSetup"`) {
+		t.Fatalf("expected setup transaction response, got %s", rr.Body.String())
+	}
+}
+
+type setupTxCall struct {
+	sync            bool
+	proposerAddress string
+	code            string
+	txType          transactions.Type
+}
+
+type setupTxService struct {
+	calls []setupTxCall
+	err   error
+}
+
+func (s *setupTxService) Create(ctx context.Context, sync bool, proposerAddress string, code string, args []transactions.Argument, tType transactions.Type) (*jobs.Job, *transactions.Transaction, error) {
+	s.calls = append(s.calls, setupTxCall{
+		sync:            sync,
+		proposerAddress: proposerAddress,
+		code:            code,
+		txType:          tType,
+	})
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+
+	id := "tx-setup-collection"
+	if len(s.calls) == 2 {
+		id = "tx-register-provider"
+	}
+
+	return &jobs.Job{
+			Type:          string(tType),
+			TransactionID: id,
+		}, &transactions.Transaction{
+			TransactionId:   id,
+			TransactionType: tType,
+			ProposerAddress: proposerAddress,
+		}, nil
+}
+
+func (s *setupTxService) Sign(ctx context.Context, proposerAddress string, code string, args []transactions.Argument) (*transactions.SignedTransaction, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) List(limit, offset int) ([]transactions.Transaction, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) ListForAccount(tType transactions.Type, address string, limit, offset int) ([]transactions.Transaction, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) Details(ctx context.Context, transactionId string) (*transactions.Transaction, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) DetailsForAccount(ctx context.Context, tType transactions.Type, address, transactionId string) (*transactions.Transaction, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) ExecuteScript(ctx context.Context, code string, args []transactions.Argument) (cadence.Value, error) {
+	panic("not used")
+}
+
+func (s *setupTxService) UpdateTransaction(t *transactions.Transaction) error {
+	panic("not used")
+}
+
+func (s *setupTxService) GetOrCreateTransaction(transactionId string) *transactions.Transaction {
+	panic("not used")
+}

--- a/main_auth_routes_test.go
+++ b/main_auth_routes_test.go
@@ -143,7 +143,7 @@ func TestTransferRouteBelongsToArtDropPlugin(t *testing.T) {
 		Templates:        handlers.NewTemplates(nil),
 		Jobs:             handlers.NewJobs(nil),
 		Accounts:         handlers.NewAccounts(nil),
-		Transactions:     handlers.NewTransactions(nil),
+		Transactions:     handlers.NewTransactions(nil, nil),
 		Tokens:           handlers.NewTokens(nil),
 		Ops:              handlers.NewOps(nil),
 		DebugURL:         "debug-url",

--- a/openapi.yml
+++ b/openapi.yml
@@ -162,6 +162,24 @@ paths:
               example-1:
                 value:
                   address: '0xf669cb8d41ce0c74'
+  '/admin/reconcile/{address}':
+    parameters:
+      - $ref: '#/components/parameters/address'
+    get:
+      summary: Reconcile account state with chain
+      description: Reconcile local account custody state from on-chain keys after graduation.
+      operationId: reconcile-account-with-chain
+      x-required-scopes:
+        - account.key.graduate
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
   /health/ready:
     get:
       summary: Healthcheck ready

--- a/templates/template_strings/transactions.go
+++ b/templates/template_strings/transactions.go
@@ -129,6 +129,42 @@ transaction(publicKeys: [String]) {
 }
 `
 
+const RotateKeyTransaction = `
+transaction(newPublicKeyHex: String, oldKeyIndex: Int, signAlgo: String, hashAlgo: String, weight: UFix64) {
+  prepare(signer: auth(Keys) &Account) {
+    var signatureAlgorithm = SignatureAlgorithm.ECDSA_P256
+    if signAlgo == "ECDSA_secp256k1" {
+      signatureAlgorithm = SignatureAlgorithm.ECDSA_secp256k1
+    } else if signAlgo != "ECDSA_P256" {
+      panic("unsupported signature algorithm")
+    }
+
+    var hashAlgorithm = HashAlgorithm.SHA3_256
+    if hashAlgo == "SHA2_256" {
+      hashAlgorithm = HashAlgorithm.SHA2_256
+    } else if hashAlgo != "SHA3_256" {
+      panic("unsupported hash algorithm")
+    }
+
+    let publicKey = PublicKey(
+      publicKey: newPublicKeyHex.decodeHex(),
+      signatureAlgorithm: signatureAlgorithm
+    )
+
+    signer.keys.add(
+      publicKey: publicKey,
+      hashAlgorithm: hashAlgorithm,
+      weight: weight
+    )
+
+    signer.keys.revoke(keyIndex: oldKeyIndex)
+  }
+}
+`
+
+// Backward-compatible alias.
+const RotateAccountKeyTransaction = RotateKeyTransaction
+
 const GraduateAccountTransaction = `
 transaction(userPublicKey: String, revokeKeyIndices: [Int]) {
   prepare(signer: auth(Keys) &Account) {
@@ -149,4 +185,3 @@ transaction(userPublicKey: String, revokeKeyIndices: [Int]) {
   }
 }
 `
-

--- a/tests/test/service.go
+++ b/tests/test/service.go
@@ -35,6 +35,7 @@ type Services interface {
 	GetKeyManager() keys.Manager
 	GetListener() chain_events.Listener
 	GetFlowClient() flow_helpers.FlowClient
+	GetDB() *upstreamgorm.DB
 }
 
 type svcs struct {
@@ -49,6 +50,7 @@ type svcs struct {
 	keyManager keys.Manager
 	listener   chain_events.Listener
 	flowClient flow_helpers.FlowClient
+	db         *upstreamgorm.DB
 }
 
 func GetDatabase(t *testing.T, cfg *configs.Config) *upstreamgorm.DB {
@@ -187,6 +189,7 @@ func GetServices(t *testing.T, cfg *configs.Config) Services {
 		keyManager: km,
 		listener:   listener,
 		flowClient: fc,
+		db:         db,
 	}
 }
 
@@ -228,4 +231,8 @@ func (s *svcs) GetSystem() system.Service {
 
 func (s *svcs) GetFlowClient() flow_helpers.FlowClient {
 	return s.flowClient
+}
+
+func (s *svcs) GetDB() *upstreamgorm.DB {
+	return s.db
 }

--- a/transactions/types.go
+++ b/transactions/types.go
@@ -12,6 +12,7 @@ const (
 	NftSetup     Type = "NftSetup"
 	NftTransfer  Type = "NftTransfer"
 	ArtDropSetup Type = "ArtDropSetup"
+	KeyRotate    Type = "KeyRotate"
 )
 
 func (s Type) String() string {
@@ -43,5 +44,7 @@ func StatusFromText(text string) Type {
 		return NftTransfer
 	case "artdropsetup":
 		return ArtDropSetup
+	case "keyrotate":
+		return KeyRotate
 	}
 }


### PR DESCRIPTION
## Summary
- Implements the ArtDrop plugin setup endpoint with embedded setup_collection and register_provider Cadence transactions.
- Adds focused service/handler tests for setup sequencing, async behavior, and created responses.
- Ports the missing W-04 post-merge pieces needed for the current string transaction type model and documents the reconcile admin route scope.

## Test Plan
- [x] env GOCACHE=/Users/qrsof/Desktop/Proyectos-David/flow-accounts-manager/.gocache go build
- [x] env GOCACHE=/Users/qrsof/Desktop/Proyectos-David/flow-accounts-manager/.gocache go test ./artdrop
- [x] env GOCACHE=/Users/qrsof/Desktop/Proyectos-David/flow-accounts-manager/.gocache go test . -run 'TestWalletAuthRulesMatchRegisteredRoutes|TestOpenAPIScopeIndexCoversFullRouter|TestTransferRouteBelongsToArtDropPlugin'
- [x] env GOCACHE=/Users/qrsof/Desktop/Proyectos-David/flow-accounts-manager/.gocache go test ./tests -run 'TestW04|TestRotate'

Closes #24