### PR TITLE
[W-03-followup] Fix migration: add explicit default for is_artist bool column

### DIFF
--- a/migrations/internal/m20260619/migration.go
+++ b/migrations/internal/m20260619/migration.go
@@ -6,7 +6,7 @@ const ID = "20260619"
 
 type Account struct {
 	Address              string `gorm:"primaryKey"`
-	IsArtist             bool
+	IsArtist             bool `gorm:"default:false"`
 	CommunityPoolAddress string
 }
 


### PR DESCRIPTION
Closes #28

Agrega `gorm:"default:false"` al campo IsArtist en la migracion m20260619.

**Motivacion:** GORM/PostgreSQL infiere DEFAULT false, pero SQLite no. Sin el tag explicito, registros existentes pueden quedar con NULL en is_artist.