### PR TITLE
W-03-followup: Replace cpLocks sync.Map with singleflight.Group to fix memory leak

### DIFF
--- a/accounts/service.go
+++ b/accounts/service.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
@@ -29,6 +28,7 @@ import (
 	flow_templates "github.com/onflow/flow-go-sdk/templates"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
+	"golang.org/x/sync/singleflight"
 )
 
 const maxGasLimit = 9999
@@ -59,7 +59,7 @@ type ServiceImpl struct {
 	txs           transactions.Service
 	temps         templates.Service
 	txRateLimiter ratelimit.Limiter
-	cpLocks       sync.Map
+	cpSF          singleflight.Group
 }
 
 // NewService initiates a new account service.
@@ -324,12 +324,18 @@ func (s *ServiceImpl) EnableCommunityPool(ctx context.Context, address string) (
 }
 
 func (s *ServiceImpl) withCommunityPoolLock(address string, fn func() (Account, error)) (Account, error) {
-	locker, _ := s.cpLocks.LoadOrStore(address, &sync.Mutex{})
-	mu := locker.(*sync.Mutex)
-	mu.Lock()
-	defer mu.Unlock()
-
-	return fn()
+	v, err, _ := s.cpSF.Do(address, func() (interface{}, error) {
+		acc, e := fn()
+		if e != nil {
+			return Account{}, e
+		}
+		return acc, nil
+	})
+	if err != nil {
+		return Account{}, err
+	}
+	acc, _ := v.(Account)
+	return acc, nil
 }
 
 func normalizeUserPublicKey(userPublicKey string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/goleak v1.3.0
 	go.uber.org/ratelimit v0.3.1
+	golang.org/x/sync v0.12.0
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6
@@ -107,7 +108,6 @@ require (
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
-	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/goleak v1.3.0
 	go.uber.org/ratelimit v0.3.1
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Replaces `cpLocks sync.Map` with `golang.org/x/sync/singleflight.Group` to fix the memory leak described in #27.

**Change:** `withCommunityPoolLock()` now uses `singleflight.Group.Do()` which deduplicates concurrent calls for the same address without accumulating stale mutexes.

**Tests:** `go test ./accounts/...` → PASS

Closes #27