### PR TITLE
W-02 polish: fix minor audit findings H4-H6

### DIFF
--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -56,6 +56,7 @@ services:
       FLOW_WALLET_LIGHTWEIGHT_MODE: "true"
       FLOW_WALLET_ACCESS_API_HOST: emulator:3569
       FLOW_WALLET_CHAIN_ID: flow-emulator
+      FLOW_WALLET_OPENAPI_SPEC_PATH: /openapi.yml
       # Cambiamos la ruta de la base de datos para que sea accesible
       FLOW_WALLET_DATABASE_DSN: "/app/data/wallet.db"
       # Opcional: Habilitar idempotencia en modo lightweight (por defecto false)

--- a/docker/wallet/Dockerfile
+++ b/docker/wallet/Dockerfile
@@ -33,6 +33,7 @@ FROM scratch as dist
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /dist/main /
+COPY --from=builder /build/openapi.yml /openapi.yml
 COPY --from=builder /build/flow/cadence /flow/cadence
 COPY --from=builder /build/artdrop/cdc /artdrop/cdc
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -554,7 +554,7 @@ paths:
       - $ref: '#/components/parameters/address'
     post:
       summary: Setup ArtDrop account
-      description: Initialize ArtDrop NFT collection and FLOW/USDC vault placeholders (FlowToken, FUSD, ExampleNFT) in a single transaction.
+      description: Initialize ArtDrop NFT collection and FLOW/FUSD vault placeholders (FlowToken, FUSD, ExampleNFT) in a single transaction.
       operationId: setupArtDropAccount
       x-required-scopes:
         - account.setup


### PR DESCRIPTION
## Summary

Resolves the remaining minimal follow-up items from issue #19.

- fixes the OpenAPI typo for the bundled setup endpoint (`FLOW/USDC` -> `FLOW/FUSD`)
- wires `FLOW_WALLET_OPENAPI_SPEC_PATH` into the lightweight Docker setup
- includes `openapi.yml` in the wallet image so that override path is available in-container
- keeps H6 unchanged because invalid addresses already return `400 Bad Request` via centralized validation

## Validation

- Manual code/path verification only
- No tests run for this change set

## Notes

- H5 is effectively addressed by making the prefixed env var available in the lightweight container path.
- H6 was reviewed and left unchanged intentionally because `flow_helpers.ValidateAddress` already returns a request-scoped `400` and `handleError` preserves it.

Closes #19