### PR TITLE
W-02 follow-up: corregir hallazgos de auditoría H1-H3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,12 @@ jobs:
           go test ./handlers/... ./configs/...
           go test -run 'Auth|Route|Scope' .
 
-  # W-02 integration coverage only needs a clean Flow emulator.
-  # Avoid deploying the legacy local Cadence contracts here: that stack is
-  # currently out of sync with the modern Flow CLI and is unrelated to this PR.
+  # Emulator-backed integration coverage should exercise the shared account and
+  # transaction flows, not only the W-02-specific tests.
   integration:
     runs-on: ubuntu-latest
+    env:
+      FLOW_EMULATOR_PRIVATE_KEY: ${{ secrets.FLOW_EMULATOR_PRIVATE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,28 +41,35 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Validate emulator key secret
+        run: |
+          test -n "$FLOW_EMULATOR_PRIVATE_KEY" || {
+            echo "Missing FLOW_EMULATOR_PRIVATE_KEY secret (emulator service account key)."
+            exit 1
+          }
+
       - name: Run emulator in Docker
         run: |
           docker run -d --name flow-emulator \
             -p 3569:3569 \
-            -e FLOW_SERVICEPRIVATEKEY=91a22fbd87392b019fbe332c32695c14cf2ba5b6521476a8540228bdf1987068 \
+            -e FLOW_SERVICEPRIVATEKEY="$FLOW_EMULATOR_PRIVATE_KEY" \
             -e FLOW_SERVICEKEYSIGALGO=ECDSA_P256 \
             -e FLOW_SERVICEKEYHASHALGO=SHA3_256 \
             gcr.io/flow-container-registry/emulator:latest \
             emulator --transaction-expiry 600
           sleep 5
 
-      - name: Run W-02 integration tests
+      - name: Run emulator-backed integration tests
         env:
           FLOW_WALLET_ADMIN_ADDRESS: "0xf8d6e0586b0a20c7"
-          FLOW_WALLET_ADMIN_PRIVATE_KEY: "91a22fbd87392b019fbe332c32695c14cf2ba5b6521476a8540228bdf1987068"
+          FLOW_WALLET_ADMIN_PRIVATE_KEY: ${{ env.FLOW_EMULATOR_PRIVATE_KEY }}
           FLOW_WALLET_ADMIN_PROPOSAL_KEY_COUNT: "5"
           FLOW_WALLET_ACCESS_API_HOST: "localhost:3569"
           FLOW_WALLET_CHAIN_ID: "flow-emulator"
           FLOW_WALLET_ENCRYPTION_KEY: "faae4ed1c30f4e4555ee3a71f1044a8e"
           FLOW_WALLET_ENCRYPTION_KEY_TYPE: "local"
           FLOW_WALLET_ENABLED_TOKENS: "FUSD:0xf8d6e0586b0a20c7:fusd,FlowToken:0x0ae53cb6e3f42a79:flowToken"
-        run: go test -run 'TestW02' . ./tests/
+        run: go test . ./tests/ -p 1
 
   lint:
     runs-on: ubuntu-latest

--- a/example/service.go
+++ b/example/service.go
@@ -3,7 +3,6 @@ package example
 import (
 	"context"
 	_ "embed"
-	"strings"
 
 	"github.com/flow-hydraulics/flow-wallet-api/flow_helpers"
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
@@ -39,7 +38,7 @@ func (s *Service) SetupExampleAccount(ctx context.Context, sync bool, address st
 	}
 
 	job, tx, err := s.deps.Transactions.Create(ctx, sync, address, setupExampleCDC, nil, TransactionType)
-	if err == nil || strings.Contains(err.Error(), "vault exists") {
+	if err == nil || flow_helpers.IsVaultExistsError(err) {
 		for _, tokenName := range setupTokenNames {
 			if addErr := s.deps.Tokens.AddAccountToken(tokenName, address); addErr != nil {
 				log.

--- a/flow_helpers/transaction_errors.go
+++ b/flow_helpers/transaction_errors.go
@@ -1,0 +1,15 @@
+package flow_helpers
+
+import "strings"
+
+const vaultExistsErrSnippet = "vault exists"
+
+// IsVaultExistsError reports whether Flow surfaced the expected setup idempotency
+// panic for an already-initialized vault.
+func IsVaultExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), vaultExistsErrSnippet)
+}

--- a/flow_helpers/transaction_errors_test.go
+++ b/flow_helpers/transaction_errors_test.go
@@ -1,0 +1,28 @@
+package flow_helpers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsVaultExistsError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		if IsVaultExistsError(nil) {
+			t.Fatal("expected false for nil error")
+		}
+	})
+
+	t.Run("matches cadence panic message", func(t *testing.T) {
+		err := errors.New("transaction execution failed: [Error Code: 1101] cadence runtime error: panic: vault exists")
+		if !IsVaultExistsError(err) {
+			t.Fatal("expected vault exists error to match")
+		}
+	})
+
+	t.Run("rejects unrelated errors", func(t *testing.T) {
+		err := errors.New("transaction execution failed: missing capability")
+		if IsVaultExistsError(err) {
+			t.Fatal("expected unrelated error not to match")
+		}
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1056,10 +1056,8 @@ func TestTokenServices(t *testing.T) {
 
 		// Setup the admin account to be able to handle FUSD
 		_, _, err = svc.Setup(ctx, true, tokenName, cfg.AdminAddress)
-		if err != nil {
-			if !strings.Contains(err.Error(), "vault exists") {
-				t.Fatal(err)
-			}
+		if err != nil && !flow_helpers.IsVaultExistsError(err) {
+			t.Fatal(err)
 		}
 
 		// Create an account

--- a/tokens/service.go
+++ b/tokens/service.go
@@ -104,7 +104,7 @@ func (s *ServiceImpl) Setup(ctx context.Context, sync bool, tokenName, address s
 
 	job, tx, err := s.transactions.Create(ctx, sync, address, token.Setup, nil, txType)
 
-	if err == nil || strings.Contains(err.Error(), "vault exists") {
+	if err == nil || flow_helpers.IsVaultExistsError(err) {
 		// Handle adding token to account in database
 		if err := s.store.InsertAccountToken(&AccountToken{
 			AccountAddress: address,


### PR DESCRIPTION
Closes #18

## Qué cambió

- se extrajo `flow_helpers.IsVaultExistsError(err)` para centralizar la detección de idempotencia en setups
- se reemplazaron comparaciones directas contra la cadena `"vault exists"` en los flujos de setup de tokens/example y en la cobertura relacionada
- se amplió el job de CI con emulador para que deje de correr solo `TestW02` y ejecute `go test . ./tests/ -p 1`
- se eliminó la private key hardcodeada del workflow de GitHub Actions y se reemplazó por `secrets.FLOW_EMULATOR_PRIVATE_KEY`

## Notas

- el workflow de integración ahora falla explícitamente si `FLOW_EMULATOR_PRIVATE_KEY` no está configurado

## Validación

- `CGO_CFLAGS='-O2 -D__BLST_PORTABLE__' GOCACHE=$(pwd)/.gocache go test ./flow_helpers -run TestIsVaultExistsError`
- `CGO_CFLAGS='-O2 -D__BLST_PORTABLE__' GOCACHE=$(pwd)/.gocache go test . ./tests/ -run 'TestW02AccountCreateAuth|TestW03ArtistActivateAuth|TestW04RotateKeyAuth|TestW05GraduateToSelfCustodyAuth|TestW06TransferAuth|TestW06SignAuth'`
