### PR TITLE
[W-12] ArtDrop read endpoints: types, CDCs, skeletons

### DIFF
--- a/artdrop/cdc/get_edition_summary.cdc
+++ b/artdrop/cdc/get_edition_summary.cdc
@@ -1,0 +1,6 @@
+import "ArtDropCore"
+
+access(all)
+fun main(id: UInt64): ArtDropCore.EditionSummary? {
+    return ArtDropCore.getEditionSummary(id: id)
+}

--- a/artdrop/cdc/get_market_mode_name.cdc
+++ b/artdrop/cdc/get_market_mode_name.cdc
@@ -1,0 +1,8 @@
+/// get_market_mode_name.cdc
+/// Returns the current MarketMode name as a String.
+import "ArtDropCore"
+
+access(all)
+fun main(): String {
+    return ArtDropCore.getMarketModeName()
+}

--- a/artdrop/cdc/get_original_summary.cdc
+++ b/artdrop/cdc/get_original_summary.cdc
@@ -1,0 +1,6 @@
+import "ArtDropCore"
+
+access(all)
+fun main(id: UInt64): ArtDropCore.OriginalSummary? {
+    return ArtDropCore.getOriginalSummary(id: id)
+}

--- a/artdrop/cdc/get_platform_fee.cdc
+++ b/artdrop/cdc/get_platform_fee.cdc
@@ -1,0 +1,8 @@
+/// get_platform_fee.cdc
+/// Returns the current platform fee in basis points (0.0 = no fee).
+import "ArtDropCore"
+
+access(all)
+fun main(): UFix64 {
+    return ArtDropCore.getPlatformFee()
+}

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -183,6 +183,92 @@ func (h *Handler) ListCertificatesFunc(rw http.ResponseWriter, r *http.Request) 
 	handlers.HandleJsonResponse(rw, http.StatusOK, certs)
 }
 
+func (h *Handler) GetOriginalSummary() http.Handler {
+	return http.HandlerFunc(h.GetOriginalSummaryFunc)
+}
+
+func (h *Handler) GetOriginalSummaryFunc(rw http.ResponseWriter, r *http.Request) {
+	origId, err := strconv.ParseUint(mux.Vars(r)["origId"], 10, 64)
+	if err != nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid origId: %w", err),
+		})
+		return
+	}
+
+	summary, err := h.svc.GetOriginalSummary(r.Context(), origId)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+	if summary == nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusNotFound,
+			Err:        fmt.Errorf("original not found"),
+		})
+		return
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusOK, summary)
+}
+
+func (h *Handler) GetEditionSummary() http.Handler {
+	return http.HandlerFunc(h.GetEditionSummaryFunc)
+}
+
+func (h *Handler) GetEditionSummaryFunc(rw http.ResponseWriter, r *http.Request) {
+	edId, err := strconv.ParseUint(mux.Vars(r)["edId"], 10, 64)
+	if err != nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid edId: %w", err),
+		})
+		return
+	}
+
+	summary, err := h.svc.GetEditionSummary(r.Context(), edId)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+	if summary == nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusNotFound,
+			Err:        fmt.Errorf("edition not found"),
+		})
+		return
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusOK, summary)
+}
+
+func (h *Handler) GetPlatformFee() http.Handler {
+	return http.HandlerFunc(h.GetPlatformFeeFunc)
+}
+
+func (h *Handler) GetPlatformFeeFunc(rw http.ResponseWriter, r *http.Request) {
+	fee, err := h.svc.GetPlatformFee(r.Context())
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+	handlers.HandleJsonResponse(rw, http.StatusOK, fee)
+}
+
+func (h *Handler) GetMarketMode() http.Handler {
+	return http.HandlerFunc(h.GetMarketModeFunc)
+}
+
+func (h *Handler) GetMarketModeFunc(rw http.ResponseWriter, r *http.Request) {
+	mode, err := h.svc.GetMarketMode(r.Context())
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+	handlers.HandleJsonResponse(rw, http.StatusOK, mode)
+}
+
 func (h *Handler) GetEscrow() http.Handler {
 	return http.HandlerFunc(h.GetEscrowFunc)
 }

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -37,4 +37,8 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/refund", h.Refund()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/certificates", h.ListCertificates()).Methods(http.MethodGet)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}", h.GetEscrow()).Methods(http.MethodGet)
+	router.Handle("/artdrop/originals/{origId}", h.GetOriginalSummary()).Methods(http.MethodGet)
+	router.Handle("/artdrop/editions/{edId}", h.GetEditionSummary()).Methods(http.MethodGet)
+	router.Handle("/artdrop/config/platform-fee", h.GetPlatformFee()).Methods(http.MethodGet)
+	router.Handle("/artdrop/config/market-mode", h.GetMarketMode()).Methods(http.MethodGet)
 }

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -43,6 +43,18 @@ var cancelEscrowCDC string
 //go:embed cdc/refund_escrow.cdc
 var refundEscrowCDC string
 
+//go:embed cdc/get_original_summary.cdc
+var getOriginalSummaryCDC string
+
+//go:embed cdc/get_edition_summary.cdc
+var getEditionSummaryCDC string
+
+//go:embed cdc/get_platform_fee.cdc
+var getPlatformFeeCDC string
+
+//go:embed cdc/get_market_mode_name.cdc
+var getMarketModeNameCDC string
+
 // Service implements the artdrop plugin business logic.
 type Service struct {
 	deps plugins.PluginDeps
@@ -262,6 +274,120 @@ func (s *Service) GetEscrow(ctx context.Context, logicOwner string, escrowId uin
 		Id:     escrowId,
 		Status: uint8(status),
 	}, nil
+}
+
+// GetOriginalSummary returns a summary of an Original.
+func (s *Service) GetOriginalSummary(ctx context.Context, originalId uint64) (*OriginalSummary, error) {
+	args := []transactions.Argument{cadence.NewUInt64(originalId)}
+
+	val, err := s.deps.Transactions.ExecuteScript(ctx, getOriginalSummaryCDC, args)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_original_summary script: %w", err)
+	}
+
+	opt, ok := val.(cadence.Optional)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.Optional", val)
+	}
+	if opt.Value == nil {
+		return nil, nil
+	}
+
+	str, ok := opt.Value.(cadence.Struct)
+	if !ok {
+		return nil, fmt.Errorf("unexpected optional inner type %T, expected cadence.Struct", opt.Value)
+	}
+
+	fields := str.FieldsMappedByName()
+	var summary OriginalSummary
+	if id, ok := fields["id"].(cadence.UInt64); ok {
+		summary.Id = uint64(id)
+	}
+	if name, ok := fields["name"].(cadence.String); ok {
+		summary.Name = string(name)
+	}
+	if artist, ok := fields["artistName"].(cadence.String); ok {
+		summary.ArtistName = string(artist)
+	}
+	if editionIDs, ok := fields["editionIDs"].(cadence.Array); ok {
+		for _, v := range editionIDs.Values {
+			if id, ok := v.(cadence.UInt64); ok {
+				summary.EditionIds = append(summary.EditionIds, uint64(id))
+			}
+		}
+	}
+
+	return &summary, nil
+}
+
+// GetEditionSummary returns a summary of an Edition.
+func (s *Service) GetEditionSummary(ctx context.Context, editionId uint64) (*EditionSummary, error) {
+	args := []transactions.Argument{cadence.NewUInt64(editionId)}
+
+	val, err := s.deps.Transactions.ExecuteScript(ctx, getEditionSummaryCDC, args)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_edition_summary script: %w", err)
+	}
+
+	opt, ok := val.(cadence.Optional)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.Optional", val)
+	}
+	if opt.Value == nil {
+		return nil, nil
+	}
+
+	str, ok := opt.Value.(cadence.Struct)
+	if !ok {
+		return nil, fmt.Errorf("unexpected optional inner type %T, expected cadence.Struct", opt.Value)
+	}
+
+	fields := str.FieldsMappedByName()
+	var summary EditionSummary
+	if id, ok := fields["id"].(cadence.UInt64); ok {
+		summary.Id = uint64(id)
+	}
+	if state, ok := fields["state"].(cadence.UInt8); ok {
+		summary.State = uint8(state)
+	}
+	if tm, ok := fields["totalMinted"].(cadence.UInt64); ok {
+		summary.TotalMinted = uint64(tm)
+	}
+	if ms, ok := fields["maxSupply"].(cadence.UInt64); ok {
+		summary.MaxSupply = uint64(ms)
+	}
+
+	return &summary, nil
+}
+
+// GetPlatformFee returns the current platform fee.
+func (s *Service) GetPlatformFee(ctx context.Context) (*PlatformFeeResponse, error) {
+	val, err := s.deps.Transactions.ExecuteScript(ctx, getPlatformFeeCDC, nil)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_platform_fee script: %w", err)
+	}
+
+	fee, ok := val.(cadence.UFix64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.UFix64", val)
+	}
+
+	return &PlatformFeeResponse{Fee: fee.String()}, nil
+}
+
+// GetMarketMode returns the current market mode name.
+func (s *Service) GetMarketMode(ctx context.Context) (*MarketModeResponse, error) {
+	val, err := s.deps.Transactions.ExecuteScript(ctx, getMarketModeNameCDC, nil)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_market_mode_name script: %w", err)
+	}
+
+	mode, ok := val.(cadence.String)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.String", val)
+	}
+
+	return &MarketModeResponse{Mode: string(mode)}, nil
 }
 
 func (s *Service) escrowAction(ctx context.Context, sync bool, address string, escrowId uint64, req EscrowActionRequest, code string, txType transactions.Type) (*jobs.Job, *transactions.Transaction, error) {

--- a/artdrop/types.go
+++ b/artdrop/types.go
@@ -62,3 +62,46 @@ type EscrowSummary struct {
 	Id     uint64 `json:"id"`
 	Status uint8  `json:"status"`
 }
+
+// OriginalSummary contains the metadata of an ArtDrop Original.
+type OriginalSummary struct {
+	Id          uint64  `json:"id"`
+	Name        string  `json:"name"`
+	ArtistName  string  `json:"artistName"`
+	EditionIds  []uint64 `json:"editionIds,omitempty"`
+}
+
+// EditionSummary contains the metadata of an ArtDrop Edition.
+type EditionSummary struct {
+	Id          uint64  `json:"id"`
+	State       uint8   `json:"state"`
+	TotalMinted uint64  `json:"totalMinted"`
+	MaxSupply   uint64  `json:"maxSupply"`
+	PrimaryPrice   string  `json:"primaryPrice,omitempty"`
+	SecondaryPrice string `json:"secondaryPrice,omitempty"`
+}
+
+// CertificateDetail holds consolidated read-only data for a single certificate.
+type CertificateDetail struct {
+	Id              uint64  `json:"id"`
+	BaseTier        *string `json:"baseTier,omitempty"`
+	ChipPubKey      []byte  `json:"chipPubKey,omitempty"`
+	IsRevealed      bool    `json:"isRevealed"`
+	FinalMultiplier *string `json:"finalMultiplier,omitempty"`
+	DisplayName     *string `json:"displayName,omitempty"`
+}
+
+// PlatformFeeResponse is the current platform fee in basis points.
+type PlatformFeeResponse struct {
+	Fee string `json:"fee"`
+}
+
+// MarketModeResponse is the current market mode name.
+type MarketModeResponse struct {
+	Mode string `json:"mode"`
+}
+
+// CollectionLengthResponse is the number of certificates in a collection.
+type CollectionLengthResponse struct {
+	Length int `json:"length"`
+}


### PR DESCRIPTION
Tipos, scripts CDC y skeletons de servicios/handlers para endpoints de lectura de Originals, Editions, Platform fee y Market mode. Rama base para que @a-david-dev y @Edgar666-debug implementen la logica completa.