### PR TITLE
Fix ArtDrop startup OpenAPI scope coverage

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -816,6 +816,72 @@ paths:
       responses:
         '200':
           description: OK
+  '/artdrop/originals/{origId}':
+    get:
+      summary: Get an ArtDrop original summary
+      operationId: getArtDropOriginalSummary
+      x-required-scopes:
+        - account.read
+      tags:
+        - Accounts
+      parameters:
+        - name: origId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: uint64
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request — invalid original ID
+        '404':
+          description: Not Found
+  '/artdrop/editions/{edId}':
+    get:
+      summary: Get an ArtDrop edition summary
+      operationId: getArtDropEditionSummary
+      x-required-scopes:
+        - account.read
+      tags:
+        - Accounts
+      parameters:
+        - name: edId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: uint64
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request — invalid edition ID
+        '404':
+          description: Not Found
+  '/artdrop/config/platform-fee':
+    get:
+      summary: Get ArtDrop platform fee configuration
+      operationId: getArtDropPlatformFee
+      x-required-scopes:
+        - account.read
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: OK
+  '/artdrop/config/market-mode':
+    get:
+      summary: Get ArtDrop market mode configuration
+      operationId: getArtDropMarketMode
+      x-required-scopes:
+        - account.read
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: OK
   '/accounts/{address}/transactions':
     parameters:
       - $ref: '#/components/parameters/address'


### PR DESCRIPTION
## Summary
- add OpenAPI auth scope entries for the four registered ArtDrop read/config routes missing from `openapi.yml`
- keep them under `account.read` so runtime auth rule generation can cover the full router

## Incident
Quave production deployment v41 for `(TESTNET)Flow Account Manager` crashes at startup with:

```text
openapi scope missing for routes: [GET /{apiVersion}/artdrop/config/market-mode GET /{apiVersion}/artdrop/config/platform-fee GET /{apiVersion}/artdrop/editions/{edId} GET /{apiVersion}/artdrop/originals/{origId}]
```

## Test plan
- PASS: `docker run --rm -v "$PWD":/src -w /src flow-accounts-manager-testdeps go test . -run 'TestWalletAuthRulesMatchRegisteredRoutes|TestOpenAPIScopeIndexCoversFullRouter|TestTransferRouteBelongsToArtDropPlugin'`
- PASS: `docker build -f docker/wallet/Dockerfile -t flow-accounts-manager-openapi-fix .`
- Known broader-suite blocker: `go test ./...` in the same Docker testdeps image now gets past the OpenAPI scope failures but still fails on tests requiring a Flow emulator at `127.0.0.1:3569`.

## Caveman explanation
Server had four ArtDrop paths, but OpenAPI rule book forgot them. Startup guard saw missing rules and killed server. This PR puts the four paths in rule book with read permission.

Closes #45
