### PR TITLE
Fix certificate detail 404 handling

### DIFF
--- a/artdrop/cdc/get_certificate_base_tier.cdc
+++ b/artdrop/cdc/get_certificate_base_tier.cdc
@@ -5,10 +5,14 @@ fun main(address: Address, id: UInt64): UFix64? {
     let collection = getAccount(address)
         .capabilities
         .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
-        ?? panic("missing certificate collection capability")
+    if collection == nil {
+        return nil
+    }
 
-    let cert = collection.borrowNFT(id) as? &ArtDropCore.Certificate
-        ?? panic("missing certificate")
+    let cert = collection!.borrowNFT(id) as? &ArtDropCore.Certificate
+    if cert == nil {
+        return nil
+    }
 
-    return cert.baseTier
+    return cert!.baseTier
 }

--- a/artdrop/cdc/get_certificate_chip_pubkey.cdc
+++ b/artdrop/cdc/get_certificate_chip_pubkey.cdc
@@ -1,14 +1,18 @@
 import ArtDropCore from 0xec581a0282d99a1a
 
 access(all)
-fun main(address: Address, id: UInt64): [UInt8] {
+fun main(address: Address, id: UInt64): [UInt8]? {
     let collection = getAccount(address)
         .capabilities
         .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
-        ?? panic("missing certificate collection capability")
+    if collection == nil {
+        return nil
+    }
 
-    let nft = collection.borrowNFT(id) as? &ArtDropCore.Certificate
-        ?? panic("missing certificate")
+    let nft = collection!.borrowNFT(id) as? &ArtDropCore.Certificate
+    if nft == nil {
+        return nil
+    }
 
-    return nft.getChipPubKeyBytes()
+    return nft!.getChipPubKeyBytes()
 }

--- a/artdrop/cdc/get_certificate_display_name.cdc
+++ b/artdrop/cdc/get_certificate_display_name.cdc
@@ -2,17 +2,23 @@ import ArtDropCore from 0xec581a0282d99a1a
 import "MetadataViews"
 
 access(all)
-fun main(address: Address, id: UInt64): String {
+fun main(address: Address, id: UInt64): String? {
     let collection = getAccount(address)
         .capabilities
         .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
-        ?? panic("missing certificate collection capability")
+    if collection == nil {
+        return nil
+    }
 
-    let nft = collection.borrowNFT(id) as? &ArtDropCore.Certificate
-        ?? panic("missing certificate")
+    let nft = collection!.borrowNFT(id) as? &ArtDropCore.Certificate
+    if nft == nil {
+        return nil
+    }
 
-    let view = nft.resolveView(Type<MetadataViews.Display>()) as? MetadataViews.Display
-        ?? panic("missing display view")
+    let view = nft!.resolveView(Type<MetadataViews.Display>()) as? MetadataViews.Display
+    if view == nil {
+        return nil
+    }
 
-    return view.name
+    return view!.name
 }

--- a/artdrop/cdc/get_certificate_final_multiplier.cdc
+++ b/artdrop/cdc/get_certificate_final_multiplier.cdc
@@ -5,10 +5,14 @@ fun main(address: Address, id: UInt64): UFix64? {
     let collection = getAccount(address)
         .capabilities
         .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
-        ?? panic("missing certificate collection capability")
+    if collection == nil {
+        return nil
+    }
 
-    let cert = collection.borrowNFT(id) as? &ArtDropCore.Certificate
-        ?? panic("missing certificate")
+    let cert = collection!.borrowNFT(id) as? &ArtDropCore.Certificate
+    if cert == nil {
+        return nil
+    }
 
-    return cert.finalMultiplier
+    return cert!.finalMultiplier
 }

--- a/artdrop/cdc/get_certificate_is_revealed.cdc
+++ b/artdrop/cdc/get_certificate_is_revealed.cdc
@@ -1,14 +1,18 @@
 import ArtDropCore from 0xec581a0282d99a1a
 
 access(all)
-fun main(address: Address, id: UInt64): Bool {
+fun main(address: Address, id: UInt64): Bool? {
     let collection = getAccount(address)
         .capabilities
         .borrow<&ArtDropCore.Collection>(ArtDropCore.CertCollectionPublicPath)
-        ?? panic("missing certificate collection capability")
+    if collection == nil {
+        return nil
+    }
 
-    let nft = collection.borrowNFT(id) as? &ArtDropCore.Certificate
-        ?? panic("missing certificate")
+    let nft = collection!.borrowNFT(id) as? &ArtDropCore.Certificate
+    if nft == nil {
+        return nil
+    }
 
-    return nft.isRevealed()
+    return nft!.isRevealed()
 }

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -202,6 +202,13 @@ func (h *Handler) GetCertificateDetailFunc(rw http.ResponseWriter, r *http.Reque
 		handlers.HandleError(rw, r, err)
 		return
 	}
+	if detail == nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusNotFound,
+			Err:        fmt.Errorf("certificate not found"),
+		})
+		return
+	}
 
 	handlers.HandleJsonResponse(rw, http.StatusOK, detail)
 }

--- a/artdrop/handler_queries_test.go
+++ b/artdrop/handler_queries_test.go
@@ -66,11 +66,11 @@ func TestListCertificatesHandlerReturnsOK(t *testing.T) {
 func TestGetCertificateDetailHandlerReturnsOK(t *testing.T) {
 	txSvc := &queryTxService{
 		scriptResults: []cadence.Value{
+			cadence.NewOptional(cadence.NewArray([]cadence.Value{cadence.NewUInt8(1), cadence.NewUInt8(2)})),
 			cadence.NewOptional(nil),
-			cadence.NewArray([]cadence.Value{cadence.NewUInt8(1), cadence.NewUInt8(2)}),
-			cadence.NewBool(false),
+			cadence.NewOptional(cadence.NewBool(false)),
 			cadence.NewOptional(nil),
-			cadence.String("Certificate #7"),
+			cadence.NewOptional(cadence.String("Certificate #7")),
 		},
 	}
 	handler := NewHandler(NewService(plugins.PluginDeps{
@@ -133,6 +133,34 @@ func TestGetCertificateDetailHandlerRejectsInvalidAddress(t *testing.T) {
 
 	if rw.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400 for invalid address, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestGetCertificateDetailHandlerReturnsNotFound(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResults: []cadence.Value{
+			cadence.NewOptional(nil),
+		},
+	}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/0xf8d6e0586b0a20c7/artdrop/certificates/7", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"address": "0xf8d6e0586b0a20c7",
+		"certId":  "7",
+	})
+	rw := httptest.NewRecorder()
+
+	handler.GetCertificateDetail().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404 for missing certificate, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if strings.Contains(rw.Body.String(), "panic") {
+		t.Fatalf("expected clean not found response without panic details, got %s", rw.Body.String())
 	}
 }
 

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -352,6 +352,19 @@ func (s *Service) GetCertificateDetail(ctx context.Context, address string, cert
 	}
 	detail := &CertificateDetail{Id: certificateId}
 
+	chipPubKey, err := s.deps.Transactions.ExecuteScript(ctx, getCertificateChipPubKeyCDC, args)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_certificate_chip_pubkey script: %w", err)
+	}
+	var found bool
+	detail.ChipPubKey, found, err = optionalUInt8ArrayBytes(chipPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode certificate chip public key: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+
 	baseTier, err := s.deps.Transactions.ExecuteScript(ctx, getCertificateBaseTierCDC, args)
 	if err != nil {
 		return nil, fmt.Errorf("execute get_certificate_base_tier script: %w", err)
@@ -360,24 +373,17 @@ func (s *Service) GetCertificateDetail(ctx context.Context, address string, cert
 		return nil, fmt.Errorf("decode certificate base tier: %w", err)
 	}
 
-	chipPubKey, err := s.deps.Transactions.ExecuteScript(ctx, getCertificateChipPubKeyCDC, args)
-	if err != nil {
-		return nil, fmt.Errorf("execute get_certificate_chip_pubkey script: %w", err)
-	}
-	detail.ChipPubKey, err = uint8ArrayBytes(chipPubKey)
-	if err != nil {
-		return nil, fmt.Errorf("decode certificate chip public key: %w", err)
-	}
-
 	isRevealed, err := s.deps.Transactions.ExecuteScript(ctx, getCertificateIsRevealedCDC, args)
 	if err != nil {
 		return nil, fmt.Errorf("execute get_certificate_is_revealed script: %w", err)
 	}
-	revealed, ok := isRevealed.(cadence.Bool)
-	if !ok {
-		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.Bool", isRevealed)
+	detail.IsRevealed, found, err = optionalBool(isRevealed)
+	if err != nil {
+		return nil, fmt.Errorf("decode certificate reveal status: %w", err)
 	}
-	detail.IsRevealed = bool(revealed)
+	if !found {
+		return nil, nil
+	}
 
 	finalMultiplier, err := s.deps.Transactions.ExecuteScript(ctx, getCertificateFinalMultiplierCDC, args)
 	if err != nil {
@@ -391,12 +397,11 @@ func (s *Service) GetCertificateDetail(ctx context.Context, address string, cert
 	if err != nil {
 		return nil, fmt.Errorf("execute get_certificate_display_name script: %w", err)
 	}
-	name, ok := displayName.(cadence.String)
-	if !ok {
-		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.String", displayName)
+	displayNameValue, err := optionalString(displayName)
+	if err != nil {
+		return nil, fmt.Errorf("decode certificate display name: %w", err)
 	}
-	value := string(name)
-	detail.DisplayName = &value
+	detail.DisplayName = displayNameValue
 
 	return detail, nil
 }
@@ -718,6 +723,55 @@ func uint8ArrayBytes(value cadence.Value) ([]byte, error) {
 		bytes = append(bytes, byte(b))
 	}
 	return bytes, nil
+}
+
+func optionalUInt8ArrayBytes(value cadence.Value) ([]byte, bool, error) {
+	opt, ok := value.(cadence.Optional)
+	if !ok {
+		return nil, false, fmt.Errorf("unexpected script result type %T, expected cadence.Optional", value)
+	}
+	if opt.Value == nil {
+		return nil, false, nil
+	}
+
+	bytes, err := uint8ArrayBytes(opt.Value)
+	if err != nil {
+		return nil, false, err
+	}
+	return bytes, true, nil
+}
+
+func optionalBool(value cadence.Value) (bool, bool, error) {
+	opt, ok := value.(cadence.Optional)
+	if !ok {
+		return false, false, fmt.Errorf("unexpected script result type %T, expected cadence.Optional", value)
+	}
+	if opt.Value == nil {
+		return false, false, nil
+	}
+
+	result, ok := opt.Value.(cadence.Bool)
+	if !ok {
+		return false, false, fmt.Errorf("unexpected optional inner type %T, expected cadence.Bool", opt.Value)
+	}
+	return bool(result), true, nil
+}
+
+func optionalString(value cadence.Value) (*string, error) {
+	opt, ok := value.(cadence.Optional)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.Optional", value)
+	}
+	if opt.Value == nil {
+		return nil, nil
+	}
+
+	result, ok := opt.Value.(cadence.String)
+	if !ok {
+		return nil, fmt.Errorf("unexpected optional inner type %T, expected cadence.String", opt.Value)
+	}
+	str := string(result)
+	return &str, nil
 }
 
 func optionalDictionaryFields(value cadence.Value) (map[string]cadence.Value, bool, error) {

--- a/artdrop/service_queries_test.go
+++ b/artdrop/service_queries_test.go
@@ -183,11 +183,11 @@ func TestGetCertificateDetailReturnsConsolidatedMetadata(t *testing.T) {
 	}
 	txSvc := &queryTxService{
 		scriptResults: []cadence.Value{
+			cadence.NewOptional(cadence.NewArray([]cadence.Value{cadence.NewUInt8(1), cadence.NewUInt8(2), cadence.NewUInt8(3)})),
 			cadence.NewOptional(baseTier),
-			cadence.NewArray([]cadence.Value{cadence.NewUInt8(1), cadence.NewUInt8(2), cadence.NewUInt8(3)}),
-			cadence.NewBool(true),
+			cadence.NewOptional(cadence.NewBool(true)),
 			cadence.NewOptional(finalMultiplier),
-			cadence.String("Certificate #7"),
+			cadence.NewOptional(cadence.String("Certificate #7")),
 		},
 	}
 	svc := NewService(plugins.PluginDeps{
@@ -233,11 +233,33 @@ func TestGetCertificateDetailReturnsConsolidatedMetadata(t *testing.T) {
 	}
 }
 
-func TestGetCertificateDetailRejectsUnexpectedChipPubKeyType(t *testing.T) {
+func TestGetCertificateDetailReturnsNilWhenCertificateMissing(t *testing.T) {
 	txSvc := &queryTxService{
 		scriptResults: []cadence.Value{
 			cadence.NewOptional(nil),
-			cadence.NewUInt64(42),
+		},
+	}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	detail, err := svc.GetCertificateDetail(context.Background(), "0xf8d6e0586b0a20c7", 7)
+	if err != nil {
+		t.Fatalf("GetCertificateDetail returned error: %v", err)
+	}
+	if detail != nil {
+		t.Fatalf("expected nil detail for missing certificate, got %+v", detail)
+	}
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected 1 script call for missing certificate, got %d", len(txSvc.calls))
+	}
+}
+
+func TestGetCertificateDetailRejectsUnexpectedChipPubKeyType(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResults: []cadence.Value{
+			cadence.NewOptional(cadence.NewUInt64(42)),
 		},
 	}
 	svc := NewService(plugins.PluginDeps{


### PR DESCRIPTION
## Summary

- Return `nil` from certificate-detail Cadence read scripts when the account has no certificate collection or the certificate is missing, instead of panicking.
- Decode the now-optional certificate fields in `GetCertificateDetail` and map missing certificates to a clean HTTP 404.
- Add focused service and handler coverage for the missing-certificate path.

## Checks

- `git diff --check` — PASS
- `go test ./artdrop` — PASS
- `go test ./artdrop -run 'TestGetCertificateDetail' -count=1 -v` — PASS
- `go test ./... -p 1` — FAIL: existing token-handler sequence-number failure in `TestTokenHandlers/create_withdrawal_valid_sync` (`invalid proposal key ... has sequence number 34, but given 33`). The same token-handler area also fails when checked against `origin/main` without this branch's changes, so this is outside the certificate-detail fix.

Closes #49
