### PR TITLE
[W-12] Completar tests de handlers y docs 404 de endpoints de lectura

### DIFF
--- a/artdrop/handler_queries_test.go
+++ b/artdrop/handler_queries_test.go
@@ -472,3 +472,150 @@ func TestGetOriginalExtendedSummaryHandlerReturnsNotFound(t *testing.T) {
 		t.Fatalf("expected status 404, got %d: %s", rw.Code, rw.Body.String())
 	}
 }
+
+func TestGetOriginalSummaryHandlerReturnsOK(t *testing.T) {
+	primary, err := cadence.NewUFix64("10.00000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewOptional(cadence.NewDictionary([]cadence.KeyValuePair{
+			{Key: cadence.String("id"), Value: cadence.NewUInt64(3)},
+			{Key: cadence.String("artist"), Value: cadence.NewAddress(flow.HexToAddress("0xf8d6e0586b0a20c7"))},
+			{Key: cadence.String("name"), Value: cadence.String("Original")},
+			{Key: cadence.String("prices"), Value: cadence.NewDictionary([]cadence.KeyValuePair{{Key: cadence.String("primary"), Value: primary}})},
+			{Key: cadence.String("createdAtBlock"), Value: cadence.NewUInt64(100)},
+			{Key: cadence.String("schemaVersion"), Value: cadence.NewUInt8(2)},
+		})),
+	}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/3", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "3"})
+	rw := httptest.NewRecorder()
+
+	handler.GetOriginalSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"id":3`) {
+		t.Fatalf("expected response to contain id 3, got %s", rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"name":"Original"`) {
+		t.Fatalf("expected response to contain name, got %s", rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"artist":"0xf8d6e0586b0a20c7"`) {
+		t.Fatalf("expected response to contain artist, got %s", rw.Body.String())
+	}
+}
+
+func TestGetOriginalSummaryHandlerRejectsInvalidOriginalId(t *testing.T) {
+	handler := NewHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/not-a-number", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "not-a-number"})
+	rw := httptest.NewRecorder()
+
+	handler.GetOriginalSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for invalid origId, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestGetOriginalSummaryHandlerReturnsNotFound(t *testing.T) {
+	txSvc := &queryTxService{scriptResult: cadence.NewOptional(nil)}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/3", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "3"})
+	rw := httptest.NewRecorder()
+
+	handler.GetOriginalSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestGetEditionSummaryHandlerReturnsOK(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewOptional(cadence.NewDictionary([]cadence.KeyValuePair{
+			{Key: cadence.String("id"), Value: cadence.NewUInt64(4)},
+			{Key: cadence.String("originalId"), Value: cadence.NewUInt64(3)},
+			{Key: cadence.String("artist"), Value: cadence.NewAddress(flow.HexToAddress("0xf8d6e0586b0a20c7"))},
+			{Key: cadence.String("shuffleSeedBlock"), Value: cadence.NewUInt64(99)},
+			{Key: cadence.String("reprintLimit"), Value: cadence.NewUInt64(500)},
+			{Key: cadence.String("maxSupply"), Value: cadence.NewUInt64(500)},
+			{Key: cadence.String("createdAtBlock"), Value: cadence.NewUInt64(101)},
+			{Key: cadence.String("schemaVersion"), Value: cadence.NewUInt8(2)},
+			{Key: cadence.String("state"), Value: cadence.NewUInt8(3)},
+			{Key: cadence.String("totalMinted"), Value: cadence.NewUInt64(9)},
+		})),
+	}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/editions/4", nil)
+	req = mux.SetURLVars(req, map[string]string{"edId": "4"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"id":4`) {
+		t.Fatalf("expected response to contain id 4, got %s", rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"state":"3"`) {
+		t.Fatalf("expected response to contain mapped state, got %s", rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"totalMinted":9`) {
+		t.Fatalf("expected response to contain totalMinted 9, got %s", rw.Body.String())
+	}
+	if !strings.Contains(rw.Body.String(), `"maxSupply":500`) {
+		t.Fatalf("expected response to contain maxSupply 500, got %s", rw.Body.String())
+	}
+}
+
+func TestGetEditionSummaryHandlerRejectsInvalidEditionId(t *testing.T) {
+	handler := NewHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/editions/not-a-number", nil)
+	req = mux.SetURLVars(req, map[string]string{"edId": "not-a-number"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for invalid edId, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestGetEditionSummaryHandlerReturnsNotFound(t *testing.T) {
+	txSvc := &queryTxService{scriptResult: cadence.NewOptional(nil)}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/editions/4", nil)
+	req = mux.SetURLVars(req, map[string]string{"edId": "4"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionSummary().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d: %s", rw.Code, rw.Body.String())
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -780,6 +780,8 @@ paths:
       responses:
         '200':
           description: OK
+        '404':
+          description: Not Found
   '/accounts/{address}/artdrop/collection-length':
     get:
       summary: Get ArtDrop collection length for an account
@@ -826,6 +828,8 @@ paths:
       responses:
         '200':
           description: OK
+        '404':
+          description: Not Found
   '/artdrop/originals/{origId}/extended':
     get:
       summary: Get an ArtDrop original extended summary
@@ -870,6 +874,8 @@ paths:
                   displayName:
                     type: string
                     nullable: true
+        '404':
+          description: Not Found
   '/artdrop/editions/{edId}':
     get:
       summary: Get an ArtDrop edition summary
@@ -887,6 +893,8 @@ paths:
       responses:
         '200':
           description: OK
+        '404':
+          description: Not Found
   '/artdrop/config/platform-fee':
     get:
       summary: Get ArtDrop platform fee


### PR DESCRIPTION
## Resumen

Cierra las dos brechas de cobertura reportadas en la issue #56 para los endpoints de lectura de W-12.

- agrega tests de handler faltantes para `GetOriginalSummary` y `GetEditionSummary`
- cubre `200`, `400` por id malformado y `404` cuando el recurso no existe
- documenta `404 Not Found` en `openapi.yml` para los 4 endpoints de lectura que ya devuelven ese status hoy

## Validación

- `env CGO_CFLAGS=-O2 -D__BLST_PORTABLE__ go test ./artdrop/...` ✅
- `go test ./auth/openapi/...` ✅

## Notas

- no cambia lógica de negocio; sólo tests de handler y documentación OpenAPI
- se mantiene el comportamiento actual: `nil` desde servicio se traduce a `404`

Closes #56