### PR TITLE
W-12: exponer endpoint de edition ids por original

### DIFF
--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -293,6 +293,10 @@ func (h *Handler) GetEditionSummary() http.Handler {
 	return http.HandlerFunc(h.GetEditionSummaryFunc)
 }
 
+func (h *Handler) GetEditionIDsByOriginal() http.Handler {
+	return http.HandlerFunc(h.GetEditionIDsByOriginalFunc)
+}
+
 func (h *Handler) GetEditionSummaryFunc(rw http.ResponseWriter, r *http.Request) {
 	edId, err := strconv.ParseUint(mux.Vars(r)["edId"], 10, 64)
 	if err != nil {
@@ -317,6 +321,25 @@ func (h *Handler) GetEditionSummaryFunc(rw http.ResponseWriter, r *http.Request)
 	}
 
 	handlers.HandleJsonResponse(rw, http.StatusOK, summary)
+}
+
+func (h *Handler) GetEditionIDsByOriginalFunc(rw http.ResponseWriter, r *http.Request) {
+	origId, err := strconv.ParseUint(mux.Vars(r)["origId"], 10, 64)
+	if err != nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid origId: %w", err),
+		})
+		return
+	}
+
+	editionIDs, err := h.svc.GetEditionIDsByOriginal(r.Context(), origId)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusOK, editionIDs)
 }
 
 func (h *Handler) GetPlatformFee() http.Handler {

--- a/artdrop/handler_queries_test.go
+++ b/artdrop/handler_queries_test.go
@@ -472,3 +472,66 @@ func TestGetOriginalExtendedSummaryHandlerReturnsNotFound(t *testing.T) {
 		t.Fatalf("expected status 404, got %d: %s", rw.Code, rw.Body.String())
 	}
 }
+
+func TestGetEditionIDsByOriginalHandlerReturnsOK(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewArray([]cadence.Value{
+			cadence.NewUInt64(11),
+			cadence.NewUInt64(12),
+		}),
+	}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/3/edition-ids", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "3"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionIDsByOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if got := strings.TrimSpace(rw.Body.String()); got != "[11,12]" {
+		t.Fatalf("expected [11,12], got %s", got)
+	}
+}
+
+func TestGetEditionIDsByOriginalHandlerRejectsInvalidOriginalId(t *testing.T) {
+	handler := NewHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/not-a-number/edition-ids", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "not-a-number"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionIDsByOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for invalid origId, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestGetEditionIDsByOriginalHandlerReturnsEmptyArray(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewArray([]cadence.Value{}),
+	}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/artdrop/originals/3/edition-ids", nil)
+	req = mux.SetURLVars(req, map[string]string{"origId": "3"})
+	rw := httptest.NewRecorder()
+
+	handler.GetEditionIDsByOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if got := strings.TrimSpace(rw.Body.String()); got != "[]" {
+		t.Fatalf("expected [], got %s", got)
+	}
+}

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -41,6 +41,7 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}", h.GetEscrow()).Methods(http.MethodGet)
 	router.Handle("/artdrop/originals/{origId}", h.GetOriginalSummary()).Methods(http.MethodGet)
 	router.Handle("/artdrop/originals/{origId}/extended", h.GetOriginalExtendedSummary()).Methods(http.MethodGet)
+	router.Handle("/artdrop/originals/{origId}/edition-ids", h.GetEditionIDsByOriginal()).Methods(http.MethodGet)
 	router.Handle("/artdrop/editions/{edId}", h.GetEditionSummary()).Methods(http.MethodGet)
 	router.Handle("/artdrop/config/platform-fee", h.GetPlatformFee()).Methods(http.MethodGet)
 	router.Handle("/artdrop/config/market-mode", h.GetMarketMode()).Methods(http.MethodGet)

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -55,6 +55,9 @@ var getOriginalExtendedSummaryCDC string
 //go:embed cdc/get_edition_summary.cdc
 var getEditionSummaryCDC string
 
+//go:embed cdc/get_edition_ids_by_original.cdc
+var getEditionIDsByOriginalCDC string
+
 //go:embed cdc/get_platform_fee.cdc
 var getPlatformFeeCDC string
 
@@ -600,6 +603,32 @@ func (s *Service) GetEditionSummary(ctx context.Context, editionId uint64) (*Edi
 	}
 
 	return &summary, nil
+}
+
+// GetEditionIDsByOriginal returns the edition IDs belonging to an Original.
+func (s *Service) GetEditionIDsByOriginal(ctx context.Context, originalId uint64) ([]uint64, error) {
+	args := []transactions.Argument{cadence.NewUInt64(originalId)}
+
+	val, err := s.deps.Transactions.ExecuteScript(ctx, getEditionIDsByOriginalCDC, args)
+	if err != nil {
+		return nil, fmt.Errorf("execute get_edition_ids_by_original script: %w", err)
+	}
+
+	arr, ok := val.(cadence.Array)
+	if !ok {
+		return nil, fmt.Errorf("unexpected script result type %T, expected cadence.Array", val)
+	}
+
+	editionIDs := make([]uint64, 0, len(arr.Values))
+	for _, v := range arr.Values {
+		id, ok := v.(cadence.UInt64)
+		if !ok {
+			return nil, fmt.Errorf("unexpected edition id type %T, expected cadence.UInt64", v)
+		}
+		editionIDs = append(editionIDs, uint64(id))
+	}
+
+	return editionIDs, nil
 }
 
 // GetPlatformFee returns the current platform fee.

--- a/artdrop/service_queries_test.go
+++ b/artdrop/service_queries_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/plugins"
 	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 )
@@ -587,6 +588,71 @@ func TestGetEditionSummaryMapsContractFields(t *testing.T) {
 	}
 	if len(summary.RarityCurve) != 2 || summary.RarityCurve[0] != 1 || summary.RarityCurve[1] != 2 {
 		t.Fatalf("unexpected rarity curve: %+v", summary.RarityCurve)
+	}
+}
+
+func TestGetEditionIDsByOriginalMapsArray(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewArray([]cadence.Value{
+			cadence.NewUInt64(11),
+			cadence.NewUInt64(12),
+			cadence.NewUInt64(13),
+		}),
+	}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	editionIDs, err := svc.GetEditionIDsByOriginal(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("GetEditionIDsByOriginal returned error: %v", err)
+	}
+	if diff := cmp.Diff([]uint64{11, 12, 13}, editionIDs); diff != "" {
+		t.Fatalf("unexpected edition ids (-want +got):\n%s", diff)
+	}
+	if len(txSvc.args) != 1 {
+		t.Fatalf("expected one script argument, got %d", len(txSvc.args))
+	}
+	idArg, ok := txSvc.args[0].(cadence.UInt64)
+	if !ok || uint64(idArg) != 3 {
+		t.Fatalf("expected originalId argument 3, got %#v", txSvc.args[0])
+	}
+}
+
+func TestGetEditionIDsByOriginalAllowsEmptyArray(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewArray([]cadence.Value{}),
+	}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	editionIDs, err := svc.GetEditionIDsByOriginal(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("GetEditionIDsByOriginal returned error: %v", err)
+	}
+	if editionIDs == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(editionIDs) != 0 {
+		t.Fatalf("expected empty slice, got %+v", editionIDs)
+	}
+}
+
+func TestGetEditionIDsByOriginalRejectsUnexpectedType(t *testing.T) {
+	txSvc := &queryTxService{
+		scriptResult: cadence.NewOptional(nil),
+	}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	_, err := svc.GetEditionIDsByOriginal(context.Background(), 3)
+	if err == nil {
+		t.Fatal("expected error for unexpected result type, got nil")
 	}
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -870,6 +870,31 @@ paths:
                   displayName:
                     type: string
                     nullable: true
+  '/artdrop/originals/{origId}/edition-ids':
+    get:
+      summary: Get ArtDrop edition ids for an original
+      operationId: getArtDropEditionIdsByOriginal
+      x-required-scopes:
+        - account.read
+      tags:
+        - Accounts
+      parameters:
+        - name: origId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+        '400':
+          description: Invalid original id
   '/artdrop/editions/{edId}':
     get:
       summary: Get an ArtDrop edition summary


### PR DESCRIPTION
## Qué cambia

- agrega el endpoint `GET /artdrop/originals/{origId}/edition-ids`
- conecta `artdrop/cdc/get_edition_ids_by_original.cdc` al servicio y handler de ArtDrop
- documenta la ruta en `openapi.yml` con respuesta `200` como arreglo de enteros y `400` para `origId` inválido
- añade tests de servicio y handler para happy path, arreglo vacío e input inválido

## Validación

- `CGO_CFLAGS='-O2 -D__BLST_PORTABLE__' GOCACHE=$(pwd)/.gocache go test ./artdrop -run 'TestGetEditionIDsByOriginal|TestGetOriginalExtendedSummary|TestGetEditionSummary'`

Closes #57
