### PR TITLE
W-12: agregar endpoints de onboarding de artista y creación de Original/Edition

### DIFF
--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -98,6 +98,77 @@ func (h *Handler) SetupFunc(rw http.ResponseWriter, r *http.Request) {
 	handlers.HandleJsonResponse(rw, http.StatusCreated, res)
 }
 
+func (h *Handler) SetupArtistDirect() http.Handler {
+	return http.HandlerFunc(h.SetupArtistDirectFunc)
+}
+
+func (h *Handler) SetupArtistDirectFunc(rw http.ResponseWriter, r *http.Request) {
+	sync := r.FormValue(handlers.SyncQueryParameter) != ""
+	job, transaction, err := h.svc.SetupArtistDirect(r.Context(), sync, mux.Vars(r)["artistAddress"])
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	var res interface{}
+	if sync {
+		res = transaction.ToJSONResponse()
+	} else {
+		res = job.ToJSONResponse()
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusCreated, res)
+}
+
+func (h *Handler) CreateOriginal() http.Handler {
+	return handlers.UseJson(http.HandlerFunc(h.CreateOriginalFunc))
+}
+
+func (h *Handler) CreateOriginalFunc(rw http.ResponseWriter, r *http.Request) {
+	var req CreateOriginalRequest
+	if !h.decodeBody(rw, r, &req) {
+		return
+	}
+
+	sync := r.FormValue(handlers.SyncQueryParameter) != ""
+	job, tx, err := h.svc.CreateOriginal(r.Context(), sync, mux.Vars(r)["artistAddress"], req)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	h.handleTransactionResponse(rw, sync, job, tx)
+}
+
+func (h *Handler) CreateEdition() http.Handler {
+	return handlers.UseJson(http.HandlerFunc(h.CreateEditionFunc))
+}
+
+func (h *Handler) CreateEditionFunc(rw http.ResponseWriter, r *http.Request) {
+	var req CreateEditionRequest
+	if !h.decodeBody(rw, r, &req) {
+		return
+	}
+
+	originalID, err := strconv.ParseUint(mux.Vars(r)["originalId"], 10, 64)
+	if err != nil {
+		handlers.HandleError(rw, r, &errors.RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid originalId: %w", err),
+		})
+		return
+	}
+
+	sync := r.FormValue(handlers.SyncQueryParameter) != ""
+	job, tx, err := h.svc.CreateEdition(r.Context(), sync, mux.Vars(r)["artistAddress"], originalID, req)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	h.handleTransactionResponse(rw, sync, job, tx)
+}
+
 func (h *Handler) CreateEscrow() http.Handler {
 	return handlers.UseJson(http.HandlerFunc(h.CreateEscrowFunc))
 }

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -6,13 +6,39 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/flow-hydraulics/flow-wallet-api/errors"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers/middleware"
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/transactions"
 	"github.com/gorilla/mux"
 )
+
+// requireArtistSubject rejects the request if the caller's token identifies a
+// specific subject (artist) that doesn't match the artistAddress in the path.
+// These endpoints let an artist create their own Original/Edition; the
+// on-chain transaction already ties identity to the signer and can't be
+// forged, but without this check any caller holding the right scope could
+// ask the wallet-api to sign on behalf of a *different* artist's custodial
+// account. Tokens without a subject claim (e.g. service/admin tokens) are
+// left untouched by this check, since this repo has no existing convention
+// for what `sub` carries — confirm with whoever issues artist tokens that
+// `sub` is set to the artist's own address for this to be effective.
+func requireArtistSubject(r *http.Request, artistAddress string) error {
+	claims, ok := middleware.ClaimsFromContext(r.Context())
+	if !ok || claims.Subject == "" {
+		return nil
+	}
+	if !strings.EqualFold(claims.Subject, artistAddress) {
+		return &errors.RequestError{
+			StatusCode: http.StatusForbidden,
+			Err:        fmt.Errorf("token subject does not match artistAddress"),
+		}
+	}
+	return nil
+}
 
 // Handler exposes HTTP endpoints for the artdrop plugin.
 type Handler struct {
@@ -103,8 +129,14 @@ func (h *Handler) SetupArtistDirect() http.Handler {
 }
 
 func (h *Handler) SetupArtistDirectFunc(rw http.ResponseWriter, r *http.Request) {
+	artistAddress := mux.Vars(r)["artistAddress"]
+	if err := requireArtistSubject(r, artistAddress); err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
 	sync := r.FormValue(handlers.SyncQueryParameter) != ""
-	job, transaction, err := h.svc.SetupArtistDirect(r.Context(), sync, mux.Vars(r)["artistAddress"])
+	job, transaction, err := h.svc.SetupArtistDirect(r.Context(), sync, artistAddress)
 	if err != nil {
 		handlers.HandleError(rw, r, err)
 		return
@@ -125,13 +157,19 @@ func (h *Handler) CreateOriginal() http.Handler {
 }
 
 func (h *Handler) CreateOriginalFunc(rw http.ResponseWriter, r *http.Request) {
+	artistAddress := mux.Vars(r)["artistAddress"]
+	if err := requireArtistSubject(r, artistAddress); err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
 	var req CreateOriginalRequest
 	if !h.decodeBody(rw, r, &req) {
 		return
 	}
 
 	sync := r.FormValue(handlers.SyncQueryParameter) != ""
-	job, tx, err := h.svc.CreateOriginal(r.Context(), sync, mux.Vars(r)["artistAddress"], req)
+	job, tx, err := h.svc.CreateOriginal(r.Context(), sync, artistAddress, req)
 	if err != nil {
 		handlers.HandleError(rw, r, err)
 		return
@@ -145,6 +183,12 @@ func (h *Handler) CreateEdition() http.Handler {
 }
 
 func (h *Handler) CreateEditionFunc(rw http.ResponseWriter, r *http.Request) {
+	artistAddress := mux.Vars(r)["artistAddress"]
+	if err := requireArtistSubject(r, artistAddress); err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
 	var req CreateEditionRequest
 	if !h.decodeBody(rw, r, &req) {
 		return
@@ -160,7 +204,7 @@ func (h *Handler) CreateEditionFunc(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	sync := r.FormValue(handlers.SyncQueryParameter) != ""
-	job, tx, err := h.svc.CreateEdition(r.Context(), sync, mux.Vars(r)["artistAddress"], originalID, req)
+	job, tx, err := h.svc.CreateEdition(r.Context(), sync, artistAddress, originalID, req)
 	if err != nil {
 		handlers.HandleError(rw, r, err)
 		return

--- a/artdrop/handler_test.go
+++ b/artdrop/handler_test.go
@@ -142,6 +142,139 @@ func TestReleaseEscrowHandlerRejectsInvalidEscrowID(t *testing.T) {
 	}
 }
 
+func TestSetupArtistDirectFuncReturnsCreatedTransaction(t *testing.T) {
+	txSvc := &setupTxService{}
+	h := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config: &configs.Config{
+			AdminAddress: "0xf8d6e0586b0a20c7",
+			ChainID:      flow.Emulator,
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/accounts/0x0ae53cb6e3f42a79/artdrop/artist-direct/setup?sync=true", nil)
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0x0ae53cb6e3f42a79"})
+	rr := httptest.NewRecorder()
+
+	h.SetupArtistDirect().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"transactionType":"ArtdropSetupArtistDirect"`) {
+		t.Fatalf("expected setup artist direct transaction response, got %s", rr.Body.String())
+	}
+}
+
+func TestCreateOriginalHandlerReturnsCreated(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"name":"Original 1","description":"Artist drop","prices":{"primary":10.5}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0xf8d6e0586b0a20c7"})
+	rw := httptest.NewRecorder()
+
+	handler.CreateOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateOriginalHandlerRequiresFields(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"description":"Artist drop","prices":{"primary":10.5}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0xf8d6e0586b0a20c7"})
+	rw := httptest.NewRecorder()
+
+	handler.CreateOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateEditionHandlerReturnsCreated(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"reprint_limit":500,"prices":{"primary":12},"profit_split":{"artist":0.85},"rarity_curve":[1,2,3],"multiplier_weights":{"rare":0.25},"rarity_profile":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals/77/editions?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{
+		"artistAddress": "0xf8d6e0586b0a20c7",
+		"originalId":    "77",
+	})
+	rw := httptest.NewRecorder()
+
+	handler.CreateEdition().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateEditionHandlerRejectsInvalidOriginalID(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"reprint_limit":500,"prices":{"primary":12},"profit_split":{"artist":0.85},"rarity_curve":[1,2,3],"multiplier_weights":{"rare":0.25},"rarity_profile":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals/not-a-number/editions?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{
+		"artistAddress": "0xf8d6e0586b0a20c7",
+		"originalId":    "not-a-number",
+	})
+	rw := httptest.NewRecorder()
+
+	handler.CreateEdition().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateEditionHandlerRequiresFields(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"reprint_limit":500,"profit_split":{"artist":0.85},"rarity_curve":[1,2,3],"multiplier_weights":{"rare":0.25},"rarity_profile":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals/77/editions?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{
+		"artistAddress": "0xf8d6e0586b0a20c7",
+		"originalId":    "77",
+	})
+	rw := httptest.NewRecorder()
+
+	handler.CreateEdition().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
 type captureTransactionService struct {
 	args []transactions.Argument
 }

--- a/artdrop/handler_test.go
+++ b/artdrop/handler_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers/middleware"
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/plugins"
 	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
@@ -203,6 +205,77 @@ func TestCreateOriginalHandlerRequiresFields(t *testing.T) {
 
 	if rw.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateOriginalHandlerRejectsMismatchedTokenSubject(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"name":"Original 1","description":"Artist drop","prices":{"primary":10.5}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0xf8d6e0586b0a20c7"})
+	req = req.WithContext(middleware.ContextWithClaims(req.Context(), &middleware.AuthClaims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "0xother00000000000"},
+	}))
+	rw := httptest.NewRecorder()
+
+	handler.CreateOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d: %s", rw.Code, rw.Body.String())
+	}
+	if len(txSvc.calls) != 0 {
+		t.Fatalf("expected no transaction to be created, got %d calls", len(txSvc.calls))
+	}
+}
+
+func TestCreateOriginalHandlerAllowsMatchingTokenSubject(t *testing.T) {
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"name":"Original 1","description":"Artist drop","prices":{"primary":10.5}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0xf8d6e0586b0a20c7"})
+	req = req.WithContext(middleware.ContextWithClaims(req.Context(), &middleware.AuthClaims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "0xf8d6e0586b0a20c7"},
+	}))
+	rw := httptest.NewRecorder()
+
+	handler.CreateOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestCreateOriginalHandlerAllowsMissingTokenSubject(t *testing.T) {
+	// A token with no subject claim (e.g. a service/admin token) is left
+	// untouched by the artistAddress check; see requireArtistSubject.
+	txSvc := &setupTxService{}
+	handler := NewHandler(NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	}))
+
+	body := `{"name":"Original 1","description":"Artist drop","prices":{"primary":10.5}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/accounts/0xf8d6e0586b0a20c7/artdrop/originals?sync=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"artistAddress": "0xf8d6e0586b0a20c7"})
+	rw := httptest.NewRecorder()
+
+	handler.CreateOriginal().ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rw.Code, rw.Body.String())
 	}
 }
 

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -28,6 +28,9 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 
 	router.Handle("/accounts/{address}/transfer", h.Transfer()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/setup", h.Setup()).Methods(http.MethodPost)
+	router.Handle("/accounts/{artistAddress}/artdrop/artist-direct/setup", h.SetupArtistDirect()).Methods(http.MethodPost)
+	router.Handle("/accounts/{artistAddress}/artdrop/originals", h.CreateOriginal()).Methods(http.MethodPost)
+	router.Handle("/accounts/{artistAddress}/artdrop/originals/{originalId}/editions", h.CreateEdition()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows", h.CreateEscrow()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate", h.ActivateChip()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate-chip", h.ActivateChip()).Methods(http.MethodPost)

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -63,6 +64,18 @@ var getMarketModeNameCDC string
 
 //go:embed cdc/is_artist.cdc
 var isArtistCDC string
+
+//go:embed cdc/onboard_artist.cdc
+var onboardArtistCDC string
+
+//go:embed cdc/setup_artist_direct_claim.cdc
+var setupArtistDirectClaimCDC string
+
+//go:embed cdc/create_original.cdc
+var createOriginalCDC string
+
+//go:embed cdc/create_edition.cdc
+var createEditionCDC string
 
 // Service implements the artdrop plugin business logic.
 type Service struct {
@@ -126,6 +139,131 @@ func (s *Service) Setup(ctx context.Context, sync bool, address string) (*jobs.J
 	}
 
 	return job, tx, nil
+}
+
+// SetupArtistDirect onboards an artist and claims ArtistDirect in the artist account.
+func (s *Service) SetupArtistDirect(ctx context.Context, sync bool, artistAddress string) (*jobs.Job, *transactions.Transaction, error) {
+	artistAddress, err := flow_helpers.ValidateAddress(artistAddress, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	adminAddress, err := flow_helpers.ValidateAddress(s.deps.Config.AdminAddress, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate admin address: %w", err)
+	}
+
+	if _, _, err := s.deps.Transactions.Create(
+		ctx,
+		true,
+		adminAddress,
+		onboardArtistCDC,
+		[]transactions.Argument{cadence.NewAddress(flow.HexToAddress(artistAddress))},
+		TxTypeSetupArtistDirect,
+	); err != nil {
+		return nil, nil, fmt.Errorf("onboard artist: %w", err)
+	}
+
+	job, tx, err := s.deps.Transactions.Create(
+		ctx,
+		sync,
+		artistAddress,
+		setupArtistDirectClaimCDC,
+		[]transactions.Argument{
+			cadence.NewAddress(flow.HexToAddress(adminAddress)),
+			cadence.String("artist-direct-" + artistAddress),
+		},
+		TxTypeSetupArtistDirect,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("claim artist direct capability: %w", err)
+	}
+
+	return job, tx, nil
+}
+
+// CreateOriginal creates an Original signed by the artist account.
+func (s *Service) CreateOriginal(ctx context.Context, sync bool, artistAddress string, req CreateOriginalRequest) (*jobs.Job, *transactions.Transaction, error) {
+	artistAddress, err := flow_helpers.ValidateAddress(artistAddress, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if req.Name == "" {
+		return nil, nil, fmt.Errorf("field 'name' is required")
+	}
+	if req.Description == "" {
+		return nil, nil, fmt.Errorf("field 'description' is required")
+	}
+	if len(req.Prices) == 0 {
+		return nil, nil, fmt.Errorf("field 'prices' is required")
+	}
+
+	prices, err := cadenceUFix64Dictionary(req.Prices)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'prices': %w", err)
+	}
+
+	return s.deps.Transactions.Create(
+		ctx,
+		sync,
+		artistAddress,
+		createOriginalCDC,
+		[]transactions.Argument{
+			cadence.String(req.Name),
+			cadence.String(req.Description),
+			prices,
+		},
+		TxTypeCreateOriginal,
+	)
+}
+
+// CreateEdition creates an Edition signed by the artist account.
+func (s *Service) CreateEdition(ctx context.Context, sync bool, artistAddress string, originalID uint64, req CreateEditionRequest) (*jobs.Job, *transactions.Transaction, error) {
+	artistAddress, err := flow_helpers.ValidateAddress(artistAddress, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(req.Prices) == 0 {
+		return nil, nil, fmt.Errorf("field 'prices' is required")
+	}
+	if len(req.ProfitSplit) == 0 {
+		return nil, nil, fmt.Errorf("field 'profit_split' is required")
+	}
+	if len(req.RarityCurve) == 0 {
+		return nil, nil, fmt.Errorf("field 'rarity_curve' is required")
+	}
+	if len(req.MultiplierWeights) == 0 {
+		return nil, nil, fmt.Errorf("field 'multiplier_weights' is required")
+	}
+
+	prices, err := cadenceUFix64Dictionary(req.Prices)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'prices': %w", err)
+	}
+	profitSplit, err := cadenceUFix64Dictionary(req.ProfitSplit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'profit_split': %w", err)
+	}
+	multiplierWeights, err := cadenceUFix64Dictionary(req.MultiplierWeights)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'multiplier_weights': %w", err)
+	}
+
+	return s.deps.Transactions.Create(
+		ctx,
+		sync,
+		artistAddress,
+		createEditionCDC,
+		[]transactions.Argument{
+			cadence.NewUInt64(originalID),
+			cadence.NewUInt64(req.ReprintLimit),
+			prices,
+			profitSplit,
+			cadenceUInt64Array(req.RarityCurve),
+			multiplierWeights,
+			cadence.NewUInt8(req.RarityProfile),
+		},
+		TxTypeCreateEdition,
+	)
 }
 
 // CreateEscrow starts a new escrow between a buyer and a seller.
@@ -753,4 +891,33 @@ func cadenceString(value cadence.Value) string {
 		return string(str)
 	}
 	return value.String()
+}
+
+func cadenceUFix64Dictionary(values map[string]float64) (cadence.Dictionary, error) {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]cadence.KeyValuePair, 0, len(keys))
+	for _, key := range keys {
+		value, err := newUFix64(values[key])
+		if err != nil {
+			return cadence.Dictionary{}, fmt.Errorf("%s: %w", key, err)
+		}
+		pairs = append(pairs, cadence.KeyValuePair{
+			Key:   cadence.String(key),
+			Value: value,
+		})
+	}
+	return cadence.NewDictionary(pairs), nil
+}
+
+func cadenceUInt64Array(values []uint64) cadence.Array {
+	cadenceValues := make([]cadence.Value, 0, len(values))
+	for _, value := range values {
+		cadenceValues = append(cadenceValues, cadence.NewUInt64(value))
+	}
+	return cadence.NewArray(cadenceValues)
 }

--- a/artdrop/service_test.go
+++ b/artdrop/service_test.go
@@ -100,6 +100,96 @@ func TestServiceSetupStopsWhenCollectionSetupFails(t *testing.T) {
 	}
 }
 
+func TestServiceSetupArtistDirectRunsOnboardThenClaim(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config: &configs.Config{
+			AdminAddress: "0xf8d6e0586b0a20c7",
+			ChainID:      flow.Emulator,
+		},
+	})
+
+	_, tx, err := svc.SetupArtistDirect(context.Background(), true, "0x0ae53cb6e3f42a79")
+	if err != nil {
+		t.Fatalf("SetupArtistDirect returned error: %v", err)
+	}
+	if tx == nil {
+		t.Fatal("expected returned transaction")
+	}
+	if len(txSvc.calls) != 2 {
+		t.Fatalf("expected 2 transactions, got %d", len(txSvc.calls))
+	}
+	if txSvc.calls[0].proposerAddress != "0xf8d6e0586b0a20c7" {
+		t.Fatalf("expected admin proposer on onboard call, got %q", txSvc.calls[0].proposerAddress)
+	}
+	if txSvc.calls[1].proposerAddress != "0x0ae53cb6e3f42a79" {
+		t.Fatalf("expected artist proposer on claim call, got %q", txSvc.calls[1].proposerAddress)
+	}
+	if !txSvc.calls[0].sync || !txSvc.calls[1].sync {
+		t.Fatal("expected sync setup to execute both transactions synchronously")
+	}
+	if txSvc.calls[0].txType != TxTypeSetupArtistDirect || txSvc.calls[1].txType != TxTypeSetupArtistDirect {
+		t.Fatalf("expected tx type %q on both calls", TxTypeSetupArtistDirect)
+	}
+	if got := txSvc.calls[0].args[0]; got != cadence.NewAddress(flow.HexToAddress("0x0ae53cb6e3f42a79")) {
+		t.Fatalf("expected onboard arg artist address, got %#v", got)
+	}
+	if got := txSvc.calls[1].args[0]; got != cadence.NewAddress(flow.HexToAddress("0xf8d6e0586b0a20c7")) {
+		t.Fatalf("expected claim arg provider address, got %#v", got)
+	}
+	if got := txSvc.calls[1].args[1]; got != cadence.String("artist-direct-0x0ae53cb6e3f42a79") {
+		t.Fatalf("expected inbox name arg, got %#v", got)
+	}
+}
+
+func TestServiceSetupArtistDirectAsyncKeepsOnboardSync(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config: &configs.Config{
+			AdminAddress: "0xf8d6e0586b0a20c7",
+			ChainID:      flow.Emulator,
+		},
+	})
+
+	job, tx, err := svc.SetupArtistDirect(context.Background(), false, "0x0ae53cb6e3f42a79")
+	if err != nil {
+		t.Fatalf("SetupArtistDirect returned error: %v", err)
+	}
+	if job == nil || tx == nil {
+		t.Fatal("expected async setup to return claim job and transaction")
+	}
+	if len(txSvc.calls) != 2 {
+		t.Fatalf("expected 2 transactions, got %d", len(txSvc.calls))
+	}
+	if !txSvc.calls[0].sync {
+		t.Fatal("expected onboard transaction to run synchronously")
+	}
+	if txSvc.calls[1].sync {
+		t.Fatal("expected claim transaction to honor async request")
+	}
+}
+
+func TestServiceSetupArtistDirectStopsWhenOnboardFails(t *testing.T) {
+	txSvc := &setupTxService{err: errors.New("onboard failed")}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config: &configs.Config{
+			AdminAddress: "0xf8d6e0586b0a20c7",
+			ChainID:      flow.Emulator,
+		},
+	})
+
+	_, _, err := svc.SetupArtistDirect(context.Background(), true, "0x0ae53cb6e3f42a79")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected only onboard transaction, got %d calls", len(txSvc.calls))
+	}
+}
+
 func TestSetupFuncReturnsCreatedTransaction(t *testing.T) {
 	txSvc := &setupTxService{}
 	h := NewHandler(NewService(plugins.PluginDeps{
@@ -118,6 +208,87 @@ func TestSetupFuncReturnsCreatedTransaction(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), `"transactionType":"ArtdropSetup"`) {
 		t.Fatalf("expected setup transaction response, got %s", rr.Body.String())
+	}
+}
+
+func TestServiceCreateOriginalUsesArtistProposerAndCadenceArgs(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	_, _, err := svc.CreateOriginal(context.Background(), true, "0xf8d6e0586b0a20c7", CreateOriginalRequest{
+		Name:        "Original 1",
+		Description: "Artist drop",
+		Prices:      map[string]float64{"primary": 10.5},
+	})
+	if err != nil {
+		t.Fatalf("CreateOriginal returned error: %v", err)
+	}
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txSvc.calls))
+	}
+	call := txSvc.calls[0]
+	if call.proposerAddress != "0xf8d6e0586b0a20c7" {
+		t.Fatalf("expected artist proposer, got %q", call.proposerAddress)
+	}
+	if call.txType != TxTypeCreateOriginal {
+		t.Fatalf("expected type %q, got %q", TxTypeCreateOriginal, call.txType)
+	}
+	if len(call.args) != 3 {
+		t.Fatalf("expected 3 args, got %d", len(call.args))
+	}
+	if _, ok := call.args[2].(cadence.Dictionary); !ok {
+		t.Fatalf("expected prices cadence dictionary, got %T", call.args[2])
+	}
+}
+
+func TestServiceCreateEditionUsesArtistProposerAndCadenceArgs(t *testing.T) {
+	txSvc := &setupTxService{}
+	svc := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config:       &configs.Config{ChainID: flow.Emulator},
+	})
+
+	_, _, err := svc.CreateEdition(context.Background(), true, "0xf8d6e0586b0a20c7", 77, CreateEditionRequest{
+		ReprintLimit:      500,
+		Prices:            map[string]float64{"primary": 12},
+		ProfitSplit:       map[string]float64{"artist": 0.85},
+		RarityCurve:       []uint64{1, 2, 3},
+		MultiplierWeights: map[string]float64{"rare": 0.25},
+		RarityProfile:     1,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdition returned error: %v", err)
+	}
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txSvc.calls))
+	}
+	call := txSvc.calls[0]
+	if call.proposerAddress != "0xf8d6e0586b0a20c7" {
+		t.Fatalf("expected artist proposer, got %q", call.proposerAddress)
+	}
+	if call.txType != TxTypeCreateEdition {
+		t.Fatalf("expected type %q, got %q", TxTypeCreateEdition, call.txType)
+	}
+	if len(call.args) != 7 {
+		t.Fatalf("expected 7 args, got %d", len(call.args))
+	}
+	if got := call.args[0]; got != cadence.NewUInt64(77) {
+		t.Fatalf("expected original id arg 77, got %#v", got)
+	}
+	if _, ok := call.args[2].(cadence.Dictionary); !ok {
+		t.Fatalf("expected prices cadence dictionary, got %T", call.args[2])
+	}
+	if _, ok := call.args[3].(cadence.Dictionary); !ok {
+		t.Fatalf("expected profit split cadence dictionary, got %T", call.args[3])
+	}
+	if _, ok := call.args[4].(cadence.Array); !ok {
+		t.Fatalf("expected rarity curve cadence array, got %T", call.args[4])
+	}
+	if _, ok := call.args[5].(cadence.Dictionary); !ok {
+		t.Fatalf("expected multiplier weights cadence dictionary, got %T", call.args[5])
 	}
 }
 

--- a/handlers/middleware/auth.go
+++ b/handlers/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"regexp"
@@ -28,6 +29,22 @@ type AuthRule struct {
 type AuthClaims struct {
 	Scope string `json:"scope"`
 	jwt.RegisteredClaims
+}
+
+type claimsContextKey struct{}
+
+// ClaimsFromContext returns the validated claims of the request's bearer
+// token, if auth ran and succeeded for this request.
+func ClaimsFromContext(ctx context.Context) (*AuthClaims, bool) {
+	claims, ok := ctx.Value(claimsContextKey{}).(*AuthClaims)
+	return claims, ok
+}
+
+// ContextWithClaims attaches claims to ctx the same way AuthHandler does.
+// Exported for tests of downstream handlers that read claims via
+// ClaimsFromContext.
+func ContextWithClaims(ctx context.Context, claims *AuthClaims) context.Context {
+	return context.WithValue(ctx, claimsContextKey{}, claims)
 }
 
 var pathParamPattern = regexp.MustCompile(`\\\{[^}]+\\\}`)
@@ -119,7 +136,8 @@ func AuthHandler(h http.Handler, opts AuthOptions) http.Handler {
 			return
 		}
 
-		h.ServeHTTP(rw, r)
+		ctx := context.WithValue(r.Context(), claimsContextKey{}, &claims)
+		h.ServeHTTP(rw, r.WithContext(ctx))
 	})
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -674,6 +674,111 @@ paths:
       responses:
         '201':
           description: Created
+  '/accounts/{artistAddress}/artdrop/artist-direct/setup':
+    post:
+      summary: Onboard an artist and claim ArtistDirect
+      operationId: setupArtDropArtistDirect
+      x-required-scopes:
+        - account.artdrop.artist.onboard
+      tags:
+        - Accounts
+      parameters:
+        - name: artistAddress
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/job'
+                  - $ref: '#/components/schemas/transactionWithEvents'
+        '400':
+          description: Bad Request — invalid artist address
+        '403':
+          description: Forbidden — wrong scope or signer not authorized
+  '/accounts/{artistAddress}/artdrop/originals':
+    post:
+      summary: Create an ArtDrop Original
+      operationId: createArtDropOriginal
+      x-required-scopes:
+        - account.artdrop.original.create
+      tags:
+        - Account Transactions
+      parameters:
+        - name: artistAddress
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/artdropCreateOriginalRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/job'
+                  - $ref: '#/components/schemas/transactionWithEvents'
+        '400':
+          description: Bad Request — missing or invalid body fields
+        '403':
+          description: Forbidden — wrong scope or signer not authorized
+  '/accounts/{artistAddress}/artdrop/originals/{originalId}/editions':
+    post:
+      summary: Create an ArtDrop Edition
+      operationId: createArtDropEdition
+      x-required-scopes:
+        - account.artdrop.edition.create
+      tags:
+        - Account Transactions
+      parameters:
+        - name: artistAddress
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: originalId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/artdropCreateEditionRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/job'
+                  - $ref: '#/components/schemas/transactionWithEvents'
+        '400':
+          description: Bad Request — missing or invalid body fields
+        '403':
+          description: Forbidden — wrong scope or signer not authorized
   '/accounts/{address}/artdrop/escrows':
     post:
       summary: Create an ArtDrop escrow
@@ -1430,6 +1535,53 @@ components:
           type: string
           description: Recipient Flow account address.
           example: '0xf8d6e0586b0a20c7'
+    artdropCreateOriginalRequest:
+      type: object
+      required:
+        - name
+        - description
+        - prices
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        prices:
+          type: object
+          additionalProperties:
+            type: number
+    artdropCreateEditionRequest:
+      type: object
+      required:
+        - reprint_limit
+        - prices
+        - profit_split
+        - rarity_curve
+        - multiplier_weights
+        - rarity_profile
+      properties:
+        reprint_limit:
+          type: integer
+          format: int64
+        prices:
+          type: object
+          additionalProperties:
+            type: number
+        profit_split:
+          type: object
+          additionalProperties:
+            type: number
+        rarity_curve:
+          type: array
+          items:
+            type: integer
+            format: int64
+        multiplier_weights:
+          type: object
+          additionalProperties:
+            type: number
+        rarity_profile:
+          type: integer
     jobState:
       type: string
       example: ACCEPTED


### PR DESCRIPTION
## Resumen
- agrega el wiring Go para los endpoints de onboarding de artista y creación de Original/Edition en ArtDrop
- reutiliza los CDC ya presentes en el repo sin tocar lógica Cadence ni config del protocolo
- documenta los endpoints nuevos en OpenAPI y agrega cobertura de tests para service y handlers

## Cambios
- `POST /accounts/{artistAddress}/artdrop/artist-direct/setup`
- `POST /accounts/{artistAddress}/artdrop/originals`
- `POST /accounts/{artistAddress}/artdrop/originals/{originalId}/editions`
- nuevos métodos de service para `SetupArtistDirect`, `CreateOriginal` y `CreateEdition`
- nuevas rutas, handlers y request schemas en `openapi.yml`
- tests unitarios para service y handlers

## Validación
- `env CGO_CFLAGS=-O2 -D__BLST_PORTABLE__ go test ./artdrop/...`
- `go test ./auth/openapi/...`

Closes #62
