### PR TITLE
fix: don't crash startup when Mongo is left unconfigured

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,8 +146,15 @@ func runServer(cfg *configs.Config) {
 		log.Fatal(err)
 	}
 	defer mongoClient.Close()
-	if err := probeMongoPricingStore(context.Background(), cfg.MongoConnectTimeout, datastoremongo.NewPricingStore(mongoClient, cfg)); err != nil {
-		log.Fatal(err)
+	if mongoClient != nil {
+		// Passing a nil *PricingStore straight into the mongoPricingProbe
+		// interface parameter would make probeMongoPricingStore's `store ==
+		// nil` check pass a typed-nil interface value, which is not nil in
+		// Go - the probe would then run against a nil receiver and fail
+		// startup even when Mongo is deliberately left unconfigured.
+		if err := probeMongoPricingStore(context.Background(), cfg.MongoConnectTimeout, datastoremongo.NewPricingStore(mongoClient, cfg)); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	systemService := system.NewService(

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/accounts"
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
 	"github.com/flow-hydraulics/flow-wallet-api/example"
 	"github.com/flow-hydraulics/flow-wallet-api/flow_helpers"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
@@ -1968,6 +1970,25 @@ func TestProbeMongoPricingStore(t *testing.T) {
 		}
 		if !seenDeadline {
 			t.Fatal("expected probe context to have deadline")
+		}
+	})
+
+	// Regression: NewPricingStore(nil, cfg) returns a nil *PricingStore, but
+	// passing that nil pointer straight into the mongoPricingProbe interface
+	// parameter does NOT make `store == nil` true inside the function - a
+	// nil concrete pointer boxed in an interface is a non-nil interface.
+	// This used to crash server startup with MONGO_URI unset (the supposedly
+	// safe default) because runServer called this exact chain unconditionally.
+	// It's fixed by guarding the whole call with `if mongoClient != nil`
+	// in main.go instead of relying on this function's nil check for that.
+	t.Run("typed-nil PricingStore boxed in the interface is not skipped", func(t *testing.T) {
+		var nilStore *datastoremongo.PricingStore = datastoremongo.NewPricingStore(nil, &configs.Config{})
+		err := probeMongoPricingStore(context.Background(), 0, nilStore)
+		if err == nil {
+			t.Fatal("expected an error: a typed-nil store boxed in the interface must not be treated as nil")
+		}
+		if !strings.Contains(err.Error(), "mongo client is not configured") {
+			t.Fatalf("expected the underlying nil-receiver error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Encontré esto probando en vivo si el servicio queda listo para prender AUTH_ENABLED=true. El servidor se caía siempre que MONGO_URI está vacío, que es el default y el caso que se suponía seguro.

La causa es un bug clásico de Go: NewPricingStore(nil, cfg) devuelve un *PricingStore nulo, pero ese puntero se pasaba directo al parámetro de tipo interfaz mongoPricingProbe. Un puntero nulo metido en una interfaz no es una interfaz nula, así que el chequeo store == nil de adentro de probeMongoPricingStore nunca se activaba. El probe seguía de largo, TestQuery fallaba con "mongo client is not configured", y ese error terminaba en log.Fatal, matando el proceso entero al arrancar.

Lo reproduje en vivo (servidor real + emulador real, sin MONGO_URI) antes y después del fix: antes se caía justo después de "Started workerpool", después llega a "Server listening" y las rutas de artdrop funcionan de punta a punta.

El fix es envolver el llamado con if mongoClient != nil en vez de confiar en el chequeo de la función interna, y agregué un test de regresión que documenta la trampa del puntero nulo en la interfaz directamente.