### PR TITLE
69: add GET /v1/studio/pricing/active endpoint with in-memory cache

### DIFF
--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -2,7 +2,10 @@ package artdrop
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/pricing"
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
 	"github.com/flow-hydraulics/flow-wallet-api/plugins"
 	"github.com/gorilla/mux"
 )
@@ -25,6 +28,18 @@ func (p *Plugin) Name() string {
 // RegisterRoutes adds the artdrop plugin routes to the API router.
 func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	h := NewHandler(p.svc)
+
+	// Studio pricing: expose the active pricing-configurations row from Mongo
+	// behind an in-memory cache invalidated when the active row's updatedAt
+	// changes. When Mongo is not configured the store is nil and the endpoint
+	// reports studio pricing as disabled (503).
+	var pricingCacheTTL time.Duration
+	if deps.Config != nil {
+		pricingCacheTTL = deps.Config.StudioPricingCacheTTL
+	}
+	pricingSvc := pricing.NewActiveService(datastoremongo.NewPricingStore(deps.Mongo, deps.Config), pricingCacheTTL)
+	pricingHandler := pricing.NewHandler(pricingSvc)
+	router.Handle("/studio/pricing/active", pricingHandler.GetActive()).Methods(http.MethodGet)
 
 	router.Handle("/accounts/{address}/transfer", h.Transfer()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/setup", h.Setup()).Methods(http.MethodPost)

--- a/artdrop/studio/pricing/handler.go
+++ b/artdrop/studio/pricing/handler.go
@@ -1,0 +1,51 @@
+package pricing
+
+import (
+	"fmt"
+	"net/http"
+
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	"github.com/flow-hydraulics/flow-wallet-api/errors"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+)
+
+// Handler exposes HTTP endpoints for studio pricing.
+type Handler struct {
+	svc *ActiveService
+}
+
+// NewHandler creates a handler backed by the given studio pricing service.
+func NewHandler(svc *ActiveService) *Handler {
+	return &Handler{svc: svc}
+}
+
+// GetActive returns the active studio-printing pricing configuration.
+func (h *Handler) GetActive() http.Handler {
+	return http.HandlerFunc(h.GetActiveFunc)
+}
+
+func (h *Handler) GetActiveFunc(rw http.ResponseWriter, r *http.Request) {
+	cfg, err := h.svc.Get(r.Context())
+	if err != nil {
+		switch {
+		case err == ErrPricingDisabled:
+			handlers.HandleError(rw, r, &errors.RequestError{
+				StatusCode: http.StatusServiceUnavailable,
+				Err:        fmt.Errorf("studio pricing is disabled: %w", err),
+			})
+		case err == datastoremongo.ErrNoActivePricing:
+			handlers.HandleError(rw, r, &errors.RequestError{
+				StatusCode: http.StatusNotFound,
+				Err:        fmt.Errorf("active studio pricing configuration not found"),
+			})
+		default:
+			handlers.HandleError(rw, r, &errors.RequestError{
+				StatusCode: http.StatusInternalServerError,
+				Err:        fmt.Errorf("read active studio pricing configuration: %w", err),
+			})
+		}
+		return
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusOK, cfg)
+}

--- a/artdrop/studio/pricing/handler.go
+++ b/artdrop/studio/pricing/handler.go
@@ -1,12 +1,14 @@
 package pricing
 
 import (
+	stdErrs "errors"
 	"fmt"
 	"net/http"
 
 	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
 	"github.com/flow-hydraulics/flow-wallet-api/errors"
 	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+	log "github.com/sirupsen/logrus"
 )
 
 // Handler exposes HTTP endpoints for studio pricing.
@@ -28,21 +30,21 @@ func (h *Handler) GetActiveFunc(rw http.ResponseWriter, r *http.Request) {
 	cfg, err := h.svc.Get(r.Context())
 	if err != nil {
 		switch {
-		case err == ErrPricingDisabled:
+		case stdErrs.Is(err, ErrPricingDisabled):
 			handlers.HandleError(rw, r, &errors.RequestError{
 				StatusCode: http.StatusServiceUnavailable,
-				Err:        fmt.Errorf("studio pricing is disabled: %w", err),
+				Err:        fmt.Errorf("studio pricing is disabled"),
 			})
-		case err == datastoremongo.ErrNoActivePricing:
+		case stdErrs.Is(err, datastoremongo.ErrNoActivePricing):
 			handlers.HandleError(rw, r, &errors.RequestError{
 				StatusCode: http.StatusNotFound,
 				Err:        fmt.Errorf("active studio pricing configuration not found"),
 			})
 		default:
-			handlers.HandleError(rw, r, &errors.RequestError{
-				StatusCode: http.StatusInternalServerError,
-				Err:        fmt.Errorf("read active studio pricing configuration: %w", err),
-			})
+			// Log the underlying failure but never leak driver internals to the
+			// client.
+			log.WithFields(log.Fields{"error": err}).Warn("failed to read active studio pricing configuration")
+			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		return
 	}

--- a/artdrop/studio/pricing/handler_test.go
+++ b/artdrop/studio/pricing/handler_test.go
@@ -54,7 +54,11 @@ func TestGetActiveHandlerInternalError(t *testing.T) {
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d: %s", rr.Code, rr.Body.String())
 	}
-	if !strings.Contains(rr.Body.String(), "read active studio pricing configuration") {
-		t.Fatalf("expected wrapped error in body, got %s", rr.Body.String())
+	// The internal driver error must be logged, never leaked to the client.
+	if strings.Contains(rr.Body.String(), "mongo down") {
+		t.Fatalf("expected generic 500 body without internal error, got %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "internal server error") {
+		t.Fatalf("expected generic message in body, got %s", rr.Body.String())
 	}
 }

--- a/artdrop/studio/pricing/handler_test.go
+++ b/artdrop/studio/pricing/handler_test.go
@@ -1,0 +1,60 @@
+package pricing
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+)
+
+func doGetActive(svc *ActiveService) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/v1/studio/pricing/active", nil)
+	rr := httptest.NewRecorder()
+	NewHandler(svc).GetActive().ServeHTTP(rr, req)
+	return rr
+}
+
+func TestGetActiveHandlerOK(t *testing.T) {
+	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{activeConfig(time.Now())}}
+	rr := doGetActive(NewActiveService(reader, time.Minute))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"domain":"studio-printing"`) {
+		t.Fatalf("expected domain in response body, got %s", rr.Body.String())
+	}
+}
+
+func TestGetActiveHandlerDisabled(t *testing.T) {
+	rr := doGetActive(NewActiveService(nil, time.Minute))
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetActiveHandlerNotFound(t *testing.T) {
+	reader := &fakeReader{errs: []error{datastoremongo.ErrNoActivePricing}}
+	rr := doGetActive(NewActiveService(reader, time.Minute))
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetActiveHandlerInternalError(t *testing.T) {
+	reader := &fakeReader{errs: []error{errors.New("mongo down")}}
+	rr := doGetActive(NewActiveService(reader, time.Minute))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "read active studio pricing configuration") {
+		t.Fatalf("expected wrapped error in body, got %s", rr.Body.String())
+	}
+}

--- a/artdrop/studio/pricing/service.go
+++ b/artdrop/studio/pricing/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	log "github.com/sirupsen/logrus"
 )
 
 // ErrPricingDisabled is returned when the service has no Mongo reader
@@ -17,18 +18,20 @@ var ErrPricingDisabled = errors.New("studio pricing is disabled")
 // It is implemented by *datastoremongo.PricingStore.
 type ActiveConfigReader interface {
 	GetActive(ctx context.Context) (*datastoremongo.PricingConfiguration, error)
+	GetActiveUpdatedAt(ctx context.Context) (time.Time, error)
 }
 
 // ActiveService serves the active studio-printing pricing configuration
 // (GET /studio/pricing/active). It keeps the active row cached in process
-// memory so requests don't hit Mongo every time, and refreshes the cache only
-// when the active row's updatedAt changed.
+// memory so requests don't hit Mongo every time. A stale cache is re-validated
+// with a lightweight updatedAt projection and only re-fetched in full when the
+// active row's updatedAt changed.
 type ActiveService struct {
 	reader ActiveConfigReader
 	ttl    time.Duration
 	now    func() time.Time // clock, overridable in tests
 
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	cached  *datastoremongo.PricingConfiguration
 	fetched time.Time // last time the cache was validated against Mongo
 }
@@ -45,35 +48,61 @@ func NewActiveService(reader ActiveConfigReader, ttl time.Duration) *ActiveServi
 }
 
 // Get returns the active pricing configuration, serving from the in-memory
-// cache while it is fresh. Once the cache is stale, Mongo is re-read and the
-// cached value is replaced only when the active row's updatedAt changed, so an
-// unchanged row keeps serving the cached copy.
+// cache while it is fresh. Once the cache is stale, Mongo is re-checked with a
+// lightweight updatedAt projection; the full configuration is re-fetched only
+// when the active row's updatedAt changed. Cache reads take a read lock so
+// concurrent requests never block on a Mongo refresh.
 func (s *ActiveService) Get(ctx context.Context) (*datastoremongo.PricingConfiguration, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.reader == nil {
 		return nil, ErrPricingDisabled
 	}
 
 	now := s.now()
+	s.mu.RLock()
+	cached := s.cached
+	if cached != nil && now.Sub(s.fetched) < s.ttl {
+		s.mu.RUnlock()
+		return cached, nil
+	}
+	s.mu.RUnlock()
+
+	// Cache is stale or empty: take the write lock, re-check under it, then
+	// refresh. Concurrent stale requests collapse into a single refresh.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now = s.now()
 	if s.cached != nil && now.Sub(s.fetched) < s.ttl {
 		return s.cached, nil
+	}
+
+	// A cached row just needs its updatedAt re-validated before re-reading the
+	// full (potentially large) configuration document.
+	if s.cached != nil {
+		updatedAt, err := s.reader.GetActiveUpdatedAt(ctx)
+		if err != nil {
+			if errors.Is(err, datastoremongo.ErrNoActivePricing) {
+				// The active row no longer exists; stop serving the stale copy.
+				s.cached = nil
+			}
+			return nil, err
+		}
+		if updatedAt.Equal(s.cached.UpdatedAt) {
+			s.fetched = now
+			return s.cached, nil
+		}
 	}
 
 	fresh, err := s.reader.GetActive(ctx)
 	if err != nil {
 		if errors.Is(err, datastoremongo.ErrNoActivePricing) {
-			// The active row no longer exists; stop serving the stale copy.
 			s.cached = nil
 		}
 		return nil, err
 	}
 
-	if s.cached == nil || !fresh.UpdatedAt.Equal(s.cached.UpdatedAt) {
-		s.cached = fresh
-	}
+	s.cached = fresh
 	s.fetched = now
-
+	log.WithField("updatedAt", fresh.UpdatedAt).Debug("refreshed active studio pricing cache")
 	return s.cached, nil
 }

--- a/artdrop/studio/pricing/service.go
+++ b/artdrop/studio/pricing/service.go
@@ -1,0 +1,79 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+)
+
+// ErrPricingDisabled is returned when the service has no Mongo reader
+// configured (MONGO_URI empty -> pricing features disabled).
+var ErrPricingDisabled = errors.New("studio pricing is disabled")
+
+// ActiveConfigReader reads the active studio-printing pricing configuration.
+// It is implemented by *datastoremongo.PricingStore.
+type ActiveConfigReader interface {
+	GetActive(ctx context.Context) (*datastoremongo.PricingConfiguration, error)
+}
+
+// ActiveService serves the active studio-printing pricing configuration
+// (GET /studio/pricing/active). It keeps the active row cached in process
+// memory so requests don't hit Mongo every time, and refreshes the cache only
+// when the active row's updatedAt changed.
+type ActiveService struct {
+	reader ActiveConfigReader
+	ttl    time.Duration
+	now    func() time.Time // clock, overridable in tests
+
+	mu      sync.Mutex
+	cached  *datastoremongo.PricingConfiguration
+	fetched time.Time // last time the cache was validated against Mongo
+}
+
+// NewActiveService creates a cache-backed service for the active pricing
+// configuration. A nil reader (Mongo disabled) makes Get return
+// ErrPricingDisabled. ttl controls how long the cache is served before Mongo is
+// re-checked; a non-positive ttl defaults to 60s.
+func NewActiveService(reader ActiveConfigReader, ttl time.Duration) *ActiveService {
+	if ttl <= 0 {
+		ttl = 60 * time.Second
+	}
+	return &ActiveService{reader: reader, ttl: ttl, now: time.Now}
+}
+
+// Get returns the active pricing configuration, serving from the in-memory
+// cache while it is fresh. Once the cache is stale, Mongo is re-read and the
+// cached value is replaced only when the active row's updatedAt changed, so an
+// unchanged row keeps serving the cached copy.
+func (s *ActiveService) Get(ctx context.Context) (*datastoremongo.PricingConfiguration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.reader == nil {
+		return nil, ErrPricingDisabled
+	}
+
+	now := s.now()
+	if s.cached != nil && now.Sub(s.fetched) < s.ttl {
+		return s.cached, nil
+	}
+
+	fresh, err := s.reader.GetActive(ctx)
+	if err != nil {
+		if errors.Is(err, datastoremongo.ErrNoActivePricing) {
+			// The active row no longer exists; stop serving the stale copy.
+			s.cached = nil
+		}
+		return nil, err
+	}
+
+	if s.cached == nil || !fresh.UpdatedAt.Equal(s.cached.UpdatedAt) {
+		s.cached = fresh
+	}
+	s.fetched = now
+
+	return s.cached, nil
+}

--- a/artdrop/studio/pricing/service_test.go
+++ b/artdrop/studio/pricing/service_test.go
@@ -1,0 +1,165 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+)
+
+// fakeReader is a scripted ActiveConfigReader for tests. Each call consumes the
+// next queued (config, error) pair; if none remain it returns the last one.
+type fakeReader struct {
+	cfgs  []*datastoremongo.PricingConfiguration
+	errs  []error
+	calls int
+}
+
+func (f *fakeReader) GetActive(context.Context) (*datastoremongo.PricingConfiguration, error) {
+	i := f.calls
+	f.calls++
+	if i < len(f.errs) && f.errs[i] != nil {
+		return nil, f.errs[i]
+	}
+	if i < len(f.cfgs) {
+		return f.cfgs[i], nil
+	}
+	return nil, nil
+}
+
+func activeConfig(updatedAt time.Time) *datastoremongo.PricingConfiguration {
+	return &datastoremongo.PricingConfiguration{
+		Domain:        "studio-printing",
+		Status:        "active",
+		EffectiveFrom: updatedAt.Add(-time.Hour),
+		UpdatedAt:     updatedAt,
+		Data:          map[string]any{"paper_price": 1.25},
+	}
+}
+
+func TestActiveServiceGetReturnsActiveConfig(t *testing.T) {
+	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{activeConfig(time.Now())}}
+	svc := NewActiveService(reader, time.Minute)
+
+	got, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Domain != "studio-printing" {
+		t.Fatalf("expected active studio-printing config, got %+v", got)
+	}
+	if reader.calls != 1 {
+		t.Fatalf("expected 1 read, got %d", reader.calls)
+	}
+}
+
+func TestActiveServiceCacheServesWithinTTL(t *testing.T) {
+	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{activeConfig(time.Now())}}
+	svc := NewActiveService(reader, time.Minute)
+
+	if _, err := svc.Get(context.Background()); err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+	if _, err := svc.Get(context.Background()); err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if reader.calls != 1 {
+		t.Fatalf("expected cache to serve the second call (1 read), got %d reads", reader.calls)
+	}
+}
+
+func TestActiveServiceRefreshesOnUpdatedAtChange(t *testing.T) {
+	v1 := time.Now()
+	v2 := v1.Add(time.Minute)
+	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{
+		activeConfig(v1),
+		activeConfig(v2),
+	}}
+
+	svc := NewActiveService(reader, time.Minute)
+	clock := time.Now()
+	svc.now = func() time.Time { return clock }
+
+	first, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+	if !first.UpdatedAt.Equal(v1) {
+		t.Fatalf("expected first config with updatedAt %v, got %v", v1, first.UpdatedAt)
+	}
+
+	// Within TTL: same updatedAt served from cache, no re-read.
+	second, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("cached Get: %v", err)
+	}
+	if !second.UpdatedAt.Equal(v1) {
+		t.Fatalf("expected cached config, got updatedAt %v", second.UpdatedAt)
+	}
+	if reader.calls != 1 {
+		t.Fatalf("expected 1 read within TTL, got %d", reader.calls)
+	}
+
+	// Past TTL with a changed updatedAt: the cache is refreshed.
+	clock = clock.Add(2 * time.Minute)
+	third, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("refreshed Get: %v", err)
+	}
+	if !third.UpdatedAt.Equal(v2) {
+		t.Fatalf("expected refreshed config with updatedAt %v, got %v", v2, third.UpdatedAt)
+	}
+	if reader.calls != 2 {
+		t.Fatalf("expected a re-read after TTL, got %d reads", reader.calls)
+	}
+}
+
+func TestActiveServiceKeepsCacheWhenUpdatedAtUnchangedAfterTTL(t *testing.T) {
+	updated := time.Now()
+	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{
+		activeConfig(updated),
+		activeConfig(updated),
+	}}
+
+	svc := NewActiveService(reader, time.Minute)
+	clock := time.Now()
+	svc.now = func() time.Time { return clock }
+
+	if _, err := svc.Get(context.Background()); err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+
+	// Past TTL but the active row's updatedAt is unchanged: no churn, the
+	// cached copy keeps serving and the row is still fetched exactly once.
+	clock = clock.Add(2 * time.Minute)
+	got, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get after TTL: %v", err)
+	}
+	if !got.UpdatedAt.Equal(updated) {
+		t.Fatalf("expected cached updatedAt %v, got %v", updated, got.UpdatedAt)
+	}
+	if reader.calls != 2 {
+		t.Fatalf("expected a re-check after TTL (2 reads), got %d", reader.calls)
+	}
+}
+
+func TestActiveServiceNilReaderDisabled(t *testing.T) {
+	svc := NewActiveService(nil, time.Minute)
+	_, err := svc.Get(context.Background())
+	if !errors.Is(err, ErrPricingDisabled) {
+		t.Fatalf("expected ErrPricingDisabled, got %v", err)
+	}
+}
+
+func TestActiveServiceNoActiveConfig(t *testing.T) {
+	reader := &fakeReader{errs: []error{datastoremongo.ErrNoActivePricing}}
+	svc := NewActiveService(reader, time.Minute)
+
+	_, err := svc.Get(context.Background())
+	if !errors.Is(err, datastoremongo.ErrNoActivePricing) {
+		t.Fatalf("expected ErrNoActivePricing, got %v", err)
+	}
+}

--- a/artdrop/studio/pricing/service_test.go
+++ b/artdrop/studio/pricing/service_test.go
@@ -3,23 +3,34 @@ package pricing
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
 )
 
-// fakeReader is a scripted ActiveConfigReader for tests. Each call consumes the
-// next queued (config, error) pair; if none remain it returns the last one.
+// fakeReader is a scripted ActiveConfigReader for tests. GetActive consumes the
+// next (config, error) pair in order; GetActiveUpdatedAt consumes the next
+// (updatedAt, error) pair independently. delay optionally simulates a slow
+// Mongo read.
 type fakeReader struct {
-	cfgs  []*datastoremongo.PricingConfiguration
-	errs  []error
-	calls int
+	cfgs       []*datastoremongo.PricingConfiguration
+	errs       []error
+	updatedAts []time.Time
+	lightErrs  []error
+	delay      time.Duration
+
+	fullCalls  int
+	lightCalls int
 }
 
 func (f *fakeReader) GetActive(context.Context) (*datastoremongo.PricingConfiguration, error) {
-	i := f.calls
-	f.calls++
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	i := f.fullCalls
+	f.fullCalls++
 	if i < len(f.errs) && f.errs[i] != nil {
 		return nil, f.errs[i]
 	}
@@ -27,6 +38,18 @@ func (f *fakeReader) GetActive(context.Context) (*datastoremongo.PricingConfigur
 		return f.cfgs[i], nil
 	}
 	return nil, nil
+}
+
+func (f *fakeReader) GetActiveUpdatedAt(context.Context) (time.Time, error) {
+	i := f.lightCalls
+	f.lightCalls++
+	if i < len(f.lightErrs) && f.lightErrs[i] != nil {
+		return time.Time{}, f.lightErrs[i]
+	}
+	if i < len(f.updatedAts) {
+		return f.updatedAts[i], nil
+	}
+	return time.Time{}, nil
 }
 
 func activeConfig(updatedAt time.Time) *datastoremongo.PricingConfiguration {
@@ -50,8 +73,8 @@ func TestActiveServiceGetReturnsActiveConfig(t *testing.T) {
 	if got == nil || got.Domain != "studio-printing" {
 		t.Fatalf("expected active studio-printing config, got %+v", got)
 	}
-	if reader.calls != 1 {
-		t.Fatalf("expected 1 read, got %d", reader.calls)
+	if reader.fullCalls != 1 {
+		t.Fatalf("expected 1 full read, got %d", reader.fullCalls)
 	}
 }
 
@@ -65,18 +88,18 @@ func TestActiveServiceCacheServesWithinTTL(t *testing.T) {
 	if _, err := svc.Get(context.Background()); err != nil {
 		t.Fatalf("second Get: %v", err)
 	}
-	if reader.calls != 1 {
-		t.Fatalf("expected cache to serve the second call (1 read), got %d reads", reader.calls)
+	if reader.fullCalls != 1 || reader.lightCalls != 0 {
+		t.Fatalf("expected cache to serve the second call (1 full read, 0 light), got full=%d light=%d", reader.fullCalls, reader.lightCalls)
 	}
 }
 
 func TestActiveServiceRefreshesOnUpdatedAtChange(t *testing.T) {
 	v1 := time.Now()
 	v2 := v1.Add(time.Minute)
-	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{
-		activeConfig(v1),
-		activeConfig(v2),
-	}}
+	reader := &fakeReader{
+		cfgs:       []*datastoremongo.PricingConfiguration{activeConfig(v1), activeConfig(v2)},
+		updatedAts: []time.Time{v2},
+	}
 
 	svc := NewActiveService(reader, time.Minute)
 	clock := time.Now()
@@ -98,11 +121,12 @@ func TestActiveServiceRefreshesOnUpdatedAtChange(t *testing.T) {
 	if !second.UpdatedAt.Equal(v1) {
 		t.Fatalf("expected cached config, got updatedAt %v", second.UpdatedAt)
 	}
-	if reader.calls != 1 {
-		t.Fatalf("expected 1 read within TTL, got %d", reader.calls)
+	if reader.fullCalls != 1 || reader.lightCalls != 0 {
+		t.Fatalf("expected 1 full read within TTL, got full=%d light=%d", reader.fullCalls, reader.lightCalls)
 	}
 
-	// Past TTL with a changed updatedAt: the cache is refreshed.
+	// Past TTL with a changed updatedAt: the light projection detects the
+	// change and the cache is refreshed.
 	clock = clock.Add(2 * time.Minute)
 	third, err := svc.Get(context.Background())
 	if err != nil {
@@ -111,17 +135,17 @@ func TestActiveServiceRefreshesOnUpdatedAtChange(t *testing.T) {
 	if !third.UpdatedAt.Equal(v2) {
 		t.Fatalf("expected refreshed config with updatedAt %v, got %v", v2, third.UpdatedAt)
 	}
-	if reader.calls != 2 {
-		t.Fatalf("expected a re-read after TTL, got %d reads", reader.calls)
+	if reader.fullCalls != 2 || reader.lightCalls != 1 {
+		t.Fatalf("expected 2 full reads + 1 light after change, got full=%d light=%d", reader.fullCalls, reader.lightCalls)
 	}
 }
 
 func TestActiveServiceKeepsCacheWhenUpdatedAtUnchangedAfterTTL(t *testing.T) {
 	updated := time.Now()
-	reader := &fakeReader{cfgs: []*datastoremongo.PricingConfiguration{
-		activeConfig(updated),
-		activeConfig(updated),
-	}}
+	reader := &fakeReader{
+		cfgs:       []*datastoremongo.PricingConfiguration{activeConfig(updated)},
+		updatedAts: []time.Time{updated},
+	}
 
 	svc := NewActiveService(reader, time.Minute)
 	clock := time.Now()
@@ -131,8 +155,9 @@ func TestActiveServiceKeepsCacheWhenUpdatedAtUnchangedAfterTTL(t *testing.T) {
 		t.Fatalf("first Get: %v", err)
 	}
 
-	// Past TTL but the active row's updatedAt is unchanged: no churn, the
-	// cached copy keeps serving and the row is still fetched exactly once.
+	// Past TTL but the active row's updatedAt is unchanged: only the light
+	// projection runs, the full document is not re-read and the cached copy is
+	// kept.
 	clock = clock.Add(2 * time.Minute)
 	got, err := svc.Get(context.Background())
 	if err != nil {
@@ -141,8 +166,8 @@ func TestActiveServiceKeepsCacheWhenUpdatedAtUnchangedAfterTTL(t *testing.T) {
 	if !got.UpdatedAt.Equal(updated) {
 		t.Fatalf("expected cached updatedAt %v, got %v", updated, got.UpdatedAt)
 	}
-	if reader.calls != 2 {
-		t.Fatalf("expected a re-check after TTL (2 reads), got %d", reader.calls)
+	if reader.fullCalls != 1 || reader.lightCalls != 1 {
+		t.Fatalf("expected 1 full read + 1 light check (no churn), got full=%d light=%d", reader.fullCalls, reader.lightCalls)
 	}
 }
 
@@ -154,12 +179,85 @@ func TestActiveServiceNilReaderDisabled(t *testing.T) {
 	}
 }
 
-func TestActiveServiceNoActiveConfig(t *testing.T) {
+func TestActiveServiceNoActiveConfigCold(t *testing.T) {
 	reader := &fakeReader{errs: []error{datastoremongo.ErrNoActivePricing}}
 	svc := NewActiveService(reader, time.Minute)
 
 	_, err := svc.Get(context.Background())
 	if !errors.Is(err, datastoremongo.ErrNoActivePricing) {
 		t.Fatalf("expected ErrNoActivePricing, got %v", err)
+	}
+}
+
+func TestActiveServiceClearsCacheWhenActiveRowDisappears(t *testing.T) {
+	v1 := time.Now()
+	reader := &fakeReader{
+		cfgs:      []*datastoremongo.PricingConfiguration{activeConfig(v1)},
+		errs:      []error{nil, datastoremongo.ErrNoActivePricing},
+		lightErrs: []error{datastoremongo.ErrNoActivePricing},
+	}
+
+	svc := NewActiveService(reader, time.Minute)
+	clock := time.Now()
+	svc.now = func() time.Time { return clock }
+
+	if _, err := svc.Get(context.Background()); err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+	if reader.fullCalls != 1 {
+		t.Fatalf("expected 1 full read, got %d", reader.fullCalls)
+	}
+
+	// Past TTL the active row disappears: the light projection reports
+	// ErrNoActivePricing and the stale cache is cleared.
+	clock = clock.Add(2 * time.Minute)
+	if _, err := svc.Get(context.Background()); !errors.Is(err, datastoremongo.ErrNoActivePricing) {
+		t.Fatalf("expected ErrNoActivePricing after row disappears, got %v", err)
+	}
+	if reader.lightCalls != 1 {
+		t.Fatalf("expected 1 light check, got %d", reader.lightCalls)
+	}
+
+	// A subsequent Get must re-query (cache was cleared), not serve a stale row.
+	if _, err := svc.Get(context.Background()); !errors.Is(err, datastoremongo.ErrNoActivePricing) {
+		t.Fatalf("expected ErrNoActivePricing on re-query, got %v", err)
+	}
+	if reader.fullCalls != 2 {
+		t.Fatalf("expected cache cleared and a second full read, got %d", reader.fullCalls)
+	}
+}
+
+func TestActiveServiceConcurrentStaleRequestsSingleRead(t *testing.T) {
+	reader := &fakeReader{
+		cfgs:  []*datastoremongo.PricingConfiguration{activeConfig(time.Now())},
+		delay: 20 * time.Millisecond,
+	}
+	svc := NewActiveService(reader, time.Minute)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cfg, err := svc.Get(context.Background())
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if cfg == nil || cfg.Domain != "studio-printing" {
+				errCh <- errors.New("unexpected config returned")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent Get failed: %v", err)
+	}
+
+	if reader.fullCalls != 1 {
+		t.Fatalf("expected concurrent stale requests to collapse into 1 full read, got %d", reader.fullCalls)
 	}
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -193,6 +193,10 @@ type Config struct {
 	MongoPricingConfigurationsCollection string `env:"MONGO_PRICING_CONFIGURATIONS_COLLECTION" envDefault:"pricing-configurations"`
 	// MongoConnectTimeout is the timeout for establishing the Mongo connection.
 	MongoConnectTimeout time.Duration `env:"MONGO_CONNECT_TIMEOUT" envDefault:"10s"`
+	// StudioPricingCacheTTL is how long the in-memory cache of the active
+	// pricing configuration is served before Mongo is re-checked for an
+	// updatedAt change. A non-positive value falls back to the service default.
+	StudioPricingCacheTTL time.Duration `env:"STUDIO_PRICING_CACHE_TTL" envDefault:"60s"`
 }
 
 // Parse parses environment variables and flags to a valid Config.

--- a/datastore/mongo/mongo_test.go
+++ b/datastore/mongo/mongo_test.go
@@ -135,6 +135,7 @@ func TestPricingStoreGetActive(t *testing.T) {
 		if price, ok := got.Data["paper_price"].(float64); !ok || price != 1.25 {
 			mt.Fatalf("expected paper_price 1.25 in Data, got %#v", got.Data["paper_price"])
 		}
+		assertFindSortsByEffectiveFromDesc(mt)
 	})
 
 	mt.Run("returns error when no active config", func(mt *mtest.T) {
@@ -181,6 +182,7 @@ func TestPricingStoreGetActiveUpdatedAt(t *testing.T) {
 		if !got.Equal(updated) {
 			mt.Fatalf("expected updatedAt %v, got %v", updated, got)
 		}
+		assertFindSortsByEffectiveFromDesc(mt)
 	})
 
 	mt.Run("returns ErrNoActivePricing when no active config", func(mt *mtest.T) {
@@ -197,4 +199,23 @@ func TestPricingStoreGetActiveUpdatedAt(t *testing.T) {
 			mt.Fatalf("expected ErrNoActivePricing, got %v", err)
 		}
 	})
+}
+
+func assertFindSortsByEffectiveFromDesc(t *mtest.T) {
+	t.Helper()
+
+	event := t.GetStartedEvent()
+	if event == nil {
+		t.Fatal("expected a Mongo command event")
+	}
+
+	sort, ok := event.Command.Lookup("sort").DocumentOK()
+	if !ok {
+		t.Fatalf("expected find command to include sort, got %s", event.Command)
+	}
+
+	effectiveFrom := sort.Lookup("effectiveFrom")
+	if got := effectiveFrom.Int32(); got != -1 {
+		t.Fatalf("expected sort.effectiveFrom -1, got %d in command %s", got, event.Command)
+	}
 }

--- a/datastore/mongo/mongo_test.go
+++ b/datastore/mongo/mongo_test.go
@@ -154,3 +154,47 @@ func TestPricingStoreGetActive(t *testing.T) {
 		}
 	})
 }
+
+func TestPricingStoreGetActiveUpdatedAt(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("returns updatedAt via projection", func(mt *mtest.T) {
+		// BSON stores dates as millisecond precision, so the expected value is
+		// truncated to survive the mock round-trip.
+		updated := time.Now().UTC().Truncate(time.Millisecond)
+		doc := bson.D{
+			{Key: "updatedAt", Value: updated},
+		}
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "payload.pricing-configurations", mtest.FirstBatch, doc))
+
+		client := &Client{
+			client: mt.Client,
+			db:     mt.Client.Database("payload"),
+		}
+		cfg := newTestConfig("mongodb://mock")
+		s := NewPricingStore(client, cfg)
+
+		got, err := s.GetActiveUpdatedAt(context.Background())
+		if err != nil {
+			mt.Fatalf("unexpected error: %v", err)
+		}
+		if !got.Equal(updated) {
+			mt.Fatalf("expected updatedAt %v, got %v", updated, got)
+		}
+	})
+
+	mt.Run("returns ErrNoActivePricing when no active config", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, "payload.pricing-configurations", mtest.FirstBatch))
+
+		client := &Client{
+			client: mt.Client,
+			db:     mt.Client.Database("payload"),
+		}
+		cfg := newTestConfig("mongodb://mock")
+		s := NewPricingStore(client, cfg)
+
+		if _, err := s.GetActiveUpdatedAt(context.Background()); !errors.Is(err, ErrNoActivePricing) {
+			mt.Fatalf("expected ErrNoActivePricing, got %v", err)
+		}
+	})
+}

--- a/datastore/mongo/mongo_test.go
+++ b/datastore/mongo/mongo_test.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,10 +14,10 @@ import (
 // newTestConfig returns a config with Mongo settings populated.
 func newTestConfig(uri string) *configs.Config {
 	return &configs.Config{
-		MongoURI:                            uri,
-		MongoDatabase:                       "payload",
+		MongoURI:                             uri,
+		MongoDatabase:                        "payload",
 		MongoPricingConfigurationsCollection: "pricing-configurations",
-		MongoConnectTimeout:                 2 * time.Second,
+		MongoConnectTimeout:                  2 * time.Second,
 	}
 }
 
@@ -100,13 +101,14 @@ func TestPricingStoreTestQuery(t *testing.T) {
 func TestPricingStoreGetActive(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
-	mt.Run("returns active config", func(mt *mtest.T) {
+	mt.Run("returns active config with full data", func(mt *mtest.T) {
 		doc := bson.D{
 			{Key: "_id", Value: "cfg-1"},
 			{Key: "domain", Value: "studio-printing"},
 			{Key: "status", Value: "active"},
 			{Key: "effectiveFrom", Value: time.Now().Add(-time.Hour)},
 			{Key: "updatedAt", Value: time.Now()},
+			{Key: "paper_price", Value: 1.25},
 		}
 		mt.AddMockResponses(mtest.CreateCursorResponse(1, "payload.pricing-configurations", mtest.FirstBatch, doc))
 
@@ -127,13 +129,18 @@ func TestPricingStoreGetActive(t *testing.T) {
 		if got.Domain != "studio-printing" {
 			mt.Fatalf("expected domain studio-printing, got %s", got.Domain)
 		}
+		if got.Data == nil {
+			mt.Fatal("expected Data to hold the full document, got nil")
+		}
+		if price, ok := got.Data["paper_price"].(float64); !ok || price != 1.25 {
+			mt.Fatalf("expected paper_price 1.25 in Data, got %#v", got.Data["paper_price"])
+		}
 	})
 
 	mt.Run("returns error when no active config", func(mt *mtest.T) {
-		mt.AddMockResponses(mtest.CreateCommandErrorResponse(mtest.CommandError{
-			Code:    66,
-			Message: "no documents in result",
-		}))
+		// A real server signals a no-match FindOne with an empty cursor, which
+		// the driver translates to mongo.ErrNoDocuments.
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, "payload.pricing-configurations", mtest.FirstBatch))
 
 		client := &Client{
 			client: mt.Client,
@@ -142,8 +149,8 @@ func TestPricingStoreGetActive(t *testing.T) {
 		cfg := newTestConfig("mongodb://mock")
 		s := NewPricingStore(client, cfg)
 
-		if _, err := s.GetActive(context.Background()); err == nil {
-			mt.Fatal("expected error when no active config, got nil")
+		if _, err := s.GetActive(context.Background()); !errors.Is(err, ErrNoActivePricing) {
+			mt.Fatalf("expected ErrNoActivePricing, got %v", err)
 		}
 	})
 }

--- a/datastore/mongo/store.go
+++ b/datastore/mongo/store.go
@@ -2,21 +2,32 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// PricingConfiguration is the minimal read-only shape of a document in the
-// pricing-configurations collection. Only the fields needed for the test query
-// and for the downstream pricing issues are mapped; unknown fields are ignored.
+// ErrNoActivePricing is returned when no row in pricing-configurations matches
+// the active Studio printing filter (domain studio-printing, status active,
+// effectiveFrom <= now).
+var ErrNoActivePricing = errors.New("no active pricing configuration")
+
+// PricingConfiguration is the read-only shape of a document in the
+// pricing-configurations collection. The metadata fields used by the active-row
+// filter are typed; Data carries the remaining fields (rates, tiers, addons,
+// ...) of the document so pricing endpoints can return the full configuration.
 type PricingConfiguration struct {
-	Domain        string    `bson:"domain"`
-	Status        string    `bson:"status"`
-	EffectiveFrom time.Time `bson:"effectiveFrom"`
-	UpdatedAt     time.Time `bson:"updatedAt"`
+	Domain        string    `bson:"domain" json:"domain"`
+	Status        string    `bson:"status" json:"status"`
+	EffectiveFrom time.Time `bson:"effectiveFrom" json:"effectiveFrom"`
+	UpdatedAt     time.Time `bson:"updatedAt" json:"updatedAt"`
+	// Data holds the pricing fields of the document beyond the typed metadata
+	// above. It is nil when the document carries only the metadata fields.
+	Data map[string]any `bson:"-" json:"data,omitempty"`
 }
 
 // PricingStore provides read-only access to pricing data in Mongo.
@@ -71,10 +82,33 @@ func (s *PricingStore) GetActive(ctx context.Context) (*PricingConfiguration, er
 		"effectiveFrom": bson.M{"$lte": time.Now()},
 	}
 
-	var cfg PricingConfiguration
-	err := s.client.Collection(s.coll).FindOne(ctx, filter).Decode(&cfg)
+	// Decode the raw document first so both the typed metadata fields and the
+	// full document (Data) can be populated from a single query.
+	var raw bson.Raw
+	err := s.client.Collection(s.coll).FindOne(ctx, filter).Decode(&raw)
 	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNoActivePricing
+		}
 		return nil, fmt.Errorf("find active pricing-configuration: %w", err)
 	}
+
+	var cfg PricingConfiguration
+	if err := bson.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("decode active pricing-configuration: %w", err)
+	}
+
+	// Preserve the full document so pricing endpoints can return the complete
+	// active configuration. The metadata keys are already typed on the struct
+	// and are removed from Data to avoid duplication.
+	var full bson.M
+	if err := bson.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("decode active pricing-configuration data: %w", err)
+	}
+	for _, key := range []string{"_id", "domain", "status", "effectiveFrom", "updatedAt"} {
+		delete(full, key)
+	}
+	cfg.Data = full
+
 	return &cfg, nil
 }

--- a/datastore/mongo/store.go
+++ b/datastore/mongo/store.go
@@ -86,7 +86,8 @@ func (s *PricingStore) GetActive(ctx context.Context) (*PricingConfiguration, er
 	// Decode the raw document first so both the typed metadata fields and the
 	// full document (Data) can be populated from a single query.
 	var raw bson.Raw
-	err := s.client.Collection(s.coll).FindOne(ctx, filter).Decode(&raw)
+	opts := options.FindOne().SetSort(bson.D{{Key: "effectiveFrom", Value: -1}})
+	err := s.client.Collection(s.coll).FindOne(ctx, filter, opts).Decode(&raw)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrNoActivePricing
@@ -132,7 +133,9 @@ func (s *PricingStore) GetActiveUpdatedAt(ctx context.Context) (time.Time, error
 	var result struct {
 		UpdatedAt time.Time `bson:"updatedAt"`
 	}
-	opts := options.FindOne().SetProjection(bson.M{"updatedAt": 1})
+	opts := options.FindOne().
+		SetProjection(bson.M{"updatedAt": 1}).
+		SetSort(bson.D{{Key: "effectiveFrom", Value: -1}})
 	err := s.client.Collection(s.coll).FindOne(ctx, filter, opts).Decode(&result)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {

--- a/datastore/mongo/store.go
+++ b/datastore/mongo/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // ErrNoActivePricing is returned when no row in pricing-configurations matches
@@ -111,4 +112,34 @@ func (s *PricingStore) GetActive(ctx context.Context) (*PricingConfiguration, er
 	cfg.Data = full
 
 	return &cfg, nil
+}
+
+// GetActiveUpdatedAt returns the updatedAt of the active Studio printing
+// configuration using a projection, without loading the full document. It is
+// the lightweight read the cache invalidation uses to detect an updatedAt
+// change before deciding to re-fetch the full configuration.
+func (s *PricingStore) GetActiveUpdatedAt(ctx context.Context) (time.Time, error) {
+	if s == nil || s.client == nil {
+		return time.Time{}, fmt.Errorf("mongo client is not configured")
+	}
+
+	filter := bson.M{
+		"domain":        "studio-printing",
+		"status":        "active",
+		"effectiveFrom": bson.M{"$lte": time.Now()},
+	}
+
+	var result struct {
+		UpdatedAt time.Time `bson:"updatedAt"`
+	}
+	opts := options.FindOne().SetProjection(bson.M{"updatedAt": 1})
+	err := s.client.Collection(s.coll).FindOne(ctx, filter, opts).Decode(&result)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return time.Time{}, ErrNoActivePricing
+		}
+		return time.Time{}, fmt.Errorf("find active pricing-configuration updatedAt: %w", err)
+	}
+
+	return result.UpdatedAt, nil
 }

--- a/main_auth_routes_test.go
+++ b/main_auth_routes_test.go
@@ -184,6 +184,53 @@ func TestTransferRouteBelongsToArtDropPlugin(t *testing.T) {
 	t.Fatal("expected artdrop transfer route to require account.transfer")
 }
 
+func TestStudioPricingActiveRouteBelongsToArtDropPlugin(t *testing.T) {
+	handlers := routeHandlers{
+		System:           handlers.NewSystem(nil),
+		Templates:        handlers.NewTemplates(nil),
+		Jobs:             handlers.NewJobs(nil),
+		Accounts:         handlers.NewAccounts(nil),
+		Transactions:     handlers.NewTransactions(nil, nil),
+		Tokens:           handlers.NewTokens(nil),
+		Ops:              handlers.NewOps(nil),
+		DebugURL:         "debug-url",
+		DebugSHA:         "debug-sha",
+		DebugBuildTime:   "debug-build-time",
+		WorkerPoolStatus: func() (interface{}, error) { return nil, nil },
+	}
+
+	coreRouter := buildRouter(routeOptions{}, handlers, nil, plugins.PluginDeps{})
+	if routeExists(t, coreRouter, http.MethodGet, "/v1/studio/pricing/active") {
+		t.Fatal("expected /studio/pricing/active to be registered by the artdrop plugin, not the core router")
+	}
+
+	spec, err := os.ReadFile("openapi.yml")
+	if err != nil {
+		t.Fatalf("read openapi.yml: %v", err)
+	}
+	scopeIndex, err := openapi.LoadScopeIndex(spec)
+	if err != nil {
+		t.Fatalf("LoadScopeIndex: %v", err)
+	}
+
+	deps := plugins.PluginDeps{}
+	pluginRouter := buildRouter(routeOptions{}, handlers, []plugins.Plugin{artdrop.NewPlugin(deps)}, deps)
+	if !routeExists(t, pluginRouter, http.MethodGet, "/v1/studio/pricing/active") {
+		t.Fatal("expected artdrop plugin to register GET /studio/pricing/active")
+	}
+
+	rules, err := openapi.AuthRulesFromRouter(pluginRouter, scopeIndex)
+	if err != nil {
+		t.Fatalf("AuthRulesFromRouter: %v", err)
+	}
+	for _, rule := range rules {
+		if rule.Key() == "GET /{apiVersion}/studio/pricing/active" && rule.RequiredScope == "pricing.read" {
+			return
+		}
+	}
+	t.Fatal("expected studio pricing active route to require pricing.read")
+}
+
 func routeExists(t *testing.T, router *mux.Router, method string, path string) bool {
 	t.Helper()
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1028,6 +1028,25 @@ paths:
       responses:
         '200':
           description: OK
+  '/studio/pricing/active':
+    get:
+      summary: Get active studio pricing configuration
+      description: >-
+        Returns the active studio-printing pricing configuration (domain
+        studio-printing, status active, effectiveFrom <= now) served from an
+        in-memory cache invalidated when the active row's updatedAt changes.
+      operationId: getActiveStudioPricing
+      x-required-scopes:
+        - pricing.read
+      tags:
+        - Studio Pricing
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: No active studio pricing configuration
+        '503':
+          description: Studio pricing is disabled (Mongo not configured)
   '/accounts/{address}/artdrop/is-artist':
     get:
       summary: Check if address is an ArtDrop artist

--- a/tests/studio_pricing_active_auth_test.go
+++ b/tests/studio_pricing_active_auth_test.go
@@ -1,0 +1,74 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+)
+
+func TestStudioPricingActiveAuth(t *testing.T) {
+	secret := "w69-test-secret"
+	rules := []handlers.AuthRule{
+		handlers.NewAuthRule(http.MethodGet, "/{apiVersion}/studio/pricing/active", "pricing.read"),
+	}
+
+	okHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	router := mux.NewRouter()
+	router.Handle("/v1/studio/pricing/active", handlers.UseAuth(okHandler, handlers.AuthOptions{
+		Enabled: true,
+		Secret:  secret,
+		Rules:   rules,
+	})).Methods(http.MethodGet)
+
+	url := "/v1/studio/pricing/active"
+
+	t.Run("returns 401 without bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+
+	t.Run("returns 403 with wrong scope", func(t *testing.T) {
+		tok := w02SignedToken(t, secret, "account.read", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected %d, got %d", http.StatusForbidden, rr.Code)
+		}
+	})
+
+	t.Run("returns 401 with expired pricing.read token", func(t *testing.T) {
+		tok := w02SignedToken(t, secret, "pricing.read", time.Now().Add(-1*time.Minute))
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+
+	t.Run("returns 200 with pricing.read scope", func(t *testing.T) {
+		tok := w02SignedToken(t, secret, "pricing.read", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Qué cambia

Implementa el endpoint **`GET /v1/studio/pricing/active`** (issue #69), que lee la fila activa de `pricing-configurations` (domain `studio-printing`, status `active`, `effectiveFrom <= now`) y la cachea en memoria del proceso, invalidando el caché cuando cambia el `updatedAt` de la fila activa. Es la fuente de tarifas reales para el motor portado (#68) y desbloquea el siguiente issue de cálculo de precio (#70).

### Capas
- **`datastore/mongo`**: `PricingConfiguration` ahora preserva el documento completo (`Data`) además de los metadatos tipados; `GetActive` devuelve el sentinel `ErrNoActivePricing` cuando no hay fila activa (mapea `mongo.ErrNoDocuments`).
- **`artdrop/studio/pricing`** (nuevo):
  - `ActiveService`: caché en memoria (mutex) con TTL configurable; re-chequea Mongo al expirar el TTL y refresca **solo** si cambió `updatedAt`; si Mongo está deshabilitado responde `ErrPricingDisabled`.
  - `Handler`: `GET /studio/pricing/active` → `200` config activo, `404` sin fila activa, `503` Mongo deshabilitado, `500` error interno.
- **Plugin artdrop**: registra la ruta (queda como `/v1/studio/pricing/active`) y arma el service con `PluginDeps.Mongo` + `Config`.
- **`configs`**: nueva env `STUDIO_PRICING_CACHE_TTL` (default `60s`).
- **`openapi.yml`**: ruta nueva con scope `pricing.read` (requerido por los tests de paridad router↔openapi y por el middleware de auth).

## Tests
- Service: happy path, caché dentro del TTL (1 solo read), invalidación por cambio de `updatedAt`, sin cambio de `updatedAt` no hay churn, Mongo off (`ErrPricingDisabled`), sin fila activa.
- Handler: 200 / 404 / 503 / 500.
- Store: `Data` preservado + sentinel `ErrNoActivePricing`.
- Paridad: `TestStudioPricingActiveRouteBelongsToArtDropPlugin` (ruta en el plugin artdrop + scope `pricing.read`).

## Verdict `go test ./...`
Todos los paquetes OK (incluidos `datastore/mongo`, `artdrop/studio/pricing`, `artdrop` y el paquete raíz con los tests de paridad). `go vet ./...` y `gofmt` limpios.

Closes #69
