### PR TITLE
78: align LoadDataFromMap with real Mongo schema

### DIFF
--- a/artdrop/studio/pricing/from_map.go
+++ b/artdrop/studio/pricing/from_map.go
@@ -9,37 +9,64 @@ import (
 // pricing-configurations Data map for the engine to compute a quote. They
 // mirror the fields LoadData reads from variables.json. If any is missing the
 // active configuration is considered invalid and the quote is rejected.
+//
+// These are the keys as stored by Payload CMS in pricing-configurations
+// (domain: studio-printing). They differ from the internal engine key names
+// (rates_printing, rates_presentation, ...) — see mongoKeyAliases for the
+// translation. ink is special: it is nested (ink.markup) and needs an unwrap.
 var requiredRateKeys = []string{
-	"rates_printing",
-	"rates_presentation",
-	"rates_cutting",
-	"rates_fulfillment",
-	"rates_package",
-	"ink_markup",
+	"printing",
+	"presentation",
+	"cutting",
+	"fulfillment",
+	"package",
+	"ink",
 	"labor",
-	"recipe",
-	"setups",
+	"recipes",
+	"processSetups",
+}
+
+// mongoKeyAliases maps the Payload CMS top-level key names (as stored in
+// pricing-configurations) to the internal engine key names that LoadData reads
+// from variables.json. The content of each category matches field-for-field;
+// only the top-level key name differs.
+var mongoKeyAliases = map[string]string{
+	"printing":      "rates_printing",
+	"presentation":  "rates_presentation",
+	"cutting":       "rates_cutting",
+	"fulfillment":   "rates_fulfillment",
+	"package":       "rates_package",
+	"recipes":       "recipe",
+	"processSetups": "setups",
+	"labor":         "labor",
 }
 
 // LoadDataFromMap builds the engine Data from the flat pricing Data map stored
 // in Mongo (PricingConfiguration.Data) merged with the embedded reference data
 // (catalog.json and grids.json). The Mongo Data holds the rates that change
-// over time (rates_printing, rates_presentation, ..., labor, recipe, setups) as
+// over time (printing, presentation, ..., labor, recipes, processSetups) as
 // top-level keys; the catalog and grids are static reference data that the
 // engine always reads from the embedded defaults.
 //
 // This is the bridge between the cached active configuration (#69) and the
 // ported engine (#68): it lets the quote endpoint (#70) compute prices from the
 // exact rates that are active in Mongo rather than from the baked-in defaults.
+//
+// The Mongo map uses Payload CMS key names (printing, presentation, ...) which
+// differ from the internal engine key names (rates_printing, ...). This
+// function translates them (mongoKeyAliases) and unwraps ink.markup into the
+// flat ink_markup number the engine expects.
 func LoadDataFromMap(data map[string]any) (Data, error) {
 	if data == nil {
 		return Data{}, fmt.Errorf("pricing data is nil")
 	}
 
-	for _, key := range requiredRateKeys {
-		if _, ok := data[key]; !ok {
-			return Data{}, fmt.Errorf("pricing data missing required key %q", key)
-		}
+	// Translate the Payload CMS key names to the internal engine key names and
+	// unwrap ink.markup. The result is a map shaped like variables.json, which
+	// is what the engine reads.
+	normalized, err := normalizeMongoData(data)
+	if err != nil {
+		return Data{}, err
 	}
 
 	// Reference data (catalog + grids) is static and always read from the
@@ -54,19 +81,61 @@ func LoadDataFromMap(data map[string]any) (Data, error) {
 	}
 
 	return Data{
-		rp:          object(data["rates_printing"]),
-		rpr:         object(data["rates_presentation"]),
-		rc:          object(data["rates_cutting"]),
-		rf:          object(data["rates_fulfillment"]),
-		rpk:         object(data["rates_package"]),
-		inkMk:       num(data["ink_markup"]),
-		labor:       object(data["labor"]),
-		recipe:      byKey(array(data["recipe"]), "process"),
-		setups:      floatMap(object(data["setups"])),
+		rp:          object(normalized["rates_printing"]),
+		rpr:         object(normalized["rates_presentation"]),
+		rc:          object(normalized["rates_cutting"]),
+		rf:          object(normalized["rates_fulfillment"]),
+		rpk:         object(normalized["rates_package"]),
+		inkMk:       num(normalized["ink_markup"]),
+		labor:       object(normalized["labor"]),
+		recipe:      byKey(array(normalized["recipe"]), "process"),
+		setups:      floatMap(object(normalized["setups"])),
 		materials:   byKey(array(catalog["materials"]), "product"),
 		consumables: byKey(array(catalog["consumables"]), "product"),
 		addonGoods:  keyedObjects(catalog["addon_goods"]),
 		services:    keyedObjects(catalog["services"]),
 		grids:       rawGrids,
 	}, nil
+}
+
+// normalizeMongoData translates the Payload CMS top-level key names in the
+// Mongo Data map to the internal engine key names and unwraps ink.markup into a
+// flat ink_markup number. It validates that every required key is present.
+//
+// The returned map is shaped like variables.json so the rest of the engine can
+// read it unchanged.
+func normalizeMongoData(data map[string]any) (map[string]any, error) {
+	// Validate presence of the Payload CMS keys first, so a missing key yields
+	// a clear error naming the real Mongo key.
+	for _, key := range requiredRateKeys {
+		if _, ok := data[key]; !ok {
+			return nil, fmt.Errorf("pricing data missing required key %q", key)
+		}
+	}
+
+	normalized := make(map[string]any, len(data))
+	for k, v := range data {
+		// ink is nested (ink.markup) in Payload CMS; unwrap it to the flat
+		// ink_markup number the engine expects.
+		if k == "ink" {
+			inkObj, ok := v.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("pricing data key %q must be an object", k)
+			}
+			markup, ok := inkObj["markup"]
+			if !ok {
+				return nil, fmt.Errorf("pricing data key %q missing nested %q", k, "markup")
+			}
+			normalized["ink_markup"] = markup
+			continue
+		}
+		if alias, ok := mongoKeyAliases[k]; ok {
+			normalized[alias] = v
+			continue
+		}
+		// Unknown keys pass through untouched (harmless; the engine ignores
+		// keys it does not read).
+		normalized[k] = v
+	}
+	return normalized, nil
 }

--- a/artdrop/studio/pricing/from_map_fuzz_test.go
+++ b/artdrop/studio/pricing/from_map_fuzz_test.go
@@ -13,10 +13,11 @@ import (
 // test. It only checks that the chain composes safely; the full Tier A
 // invariant list already lives in FuzzCompute in pricing_fuzz_test.go.
 //
-// Seeds: the canonical Mongo-shaped variables map (loaded via the
-// embedded defaultVariablesJSON since mongoDataFromVariables(t) requires
-// *testing.T) plus explicit variants with each required key deleted
-// and a couple of value mutations. Non-parseable bytes are skipped.
+// Seeds: the canonical Mongo-shaped variables map (loaded via the embedded
+// defaultVariablesJSON and translated to the Payload CMS key names that
+// LoadDataFromMap expects, since mongoDataFromVariables(t) requires
+// *testing.T) plus explicit variants with each required key deleted and a
+// couple of value mutations. Non-parseable bytes are skipped.
 // LoadDataFromMap returning a non-nil error is treated as a legitimate
 // outcome (e.g. missing required key) and aborts the iteration with no
 // further assertions.
@@ -25,19 +26,23 @@ func FuzzLoadDataFromMap(f *testing.F) {
 	if err := json.Unmarshal(defaultVariablesJSON, &variables); err != nil {
 		f.Fatalf("unmarshal defaultVariablesJSON: %v", err)
 	}
-	canonical, err := json.Marshal(variables)
+	// Translate the internal engine key names (rates_printing, ...) to the
+	// Payload CMS key names (printing, ...) that LoadDataFromMap expects, and
+	// nest ink_markup under ink.markup.
+	mongo := internalToMongoKeys(variables)
+	canonical, err := json.Marshal(mongo)
 	if err != nil {
 		f.Fatalf("marshal canonical seed: %v", err)
 	}
 	f.Add(canonical)
 
 	for _, key := range []string{
-		"rates_printing", "rates_presentation", "rates_cutting",
-		"rates_fulfillment", "rates_package", "ink_markup",
-		"labor", "recipe", "setups",
+		"printing", "presentation", "cutting",
+		"fulfillment", "package", "ink",
+		"labor", "recipes", "processSetups",
 	} {
-		m := make(map[string]any, len(variables))
-		for k, v := range variables {
+		m := make(map[string]any, len(mongo))
+		for k, v := range mongo {
 			if k == key {
 				continue
 			}
@@ -54,10 +59,10 @@ func FuzzLoadDataFromMap(f *testing.F) {
 		name string
 		path []string
 	}{
-		{"rates_printing.bed_gap=0", []string{"rates_printing", "bed_gap"}},
-		{"rates_printing.min_order=0", []string{"rates_printing", "min_order"}},
+		{"printing.bed_gap=0", []string{"printing", "bed_gap"}},
+		{"printing.min_order=0", []string{"printing", "min_order"}},
 	} {
-		m := deepCloneMap(variables)
+		m := deepCloneMap(mongo)
 		cur := m
 		for i, p := range mutation.path {
 			if i == len(mutation.path)-1 {
@@ -128,6 +133,38 @@ func deepCloneMap(m map[string]any) map[string]any {
 		} else {
 			out[k] = v
 		}
+	}
+	return out
+}
+
+// internalToMongoKeys translates a variables.json-shaped map (internal engine
+// key names: rates_printing, ..., ink_markup, recipe, setups) into the Payload
+// CMS key names that LoadDataFromMap expects (printing, ..., ink.markup,
+// recipes, processSetups). It is the inverse of normalizeMongoData and is used
+// to build fuzz seeds that match the real Mongo schema.
+func internalToMongoKeys(m map[string]any) map[string]any {
+	// Inverse of mongoKeyAliases.
+	aliases := map[string]string{
+		"rates_printing":     "printing",
+		"rates_presentation": "presentation",
+		"rates_cutting":      "cutting",
+		"rates_fulfillment":  "fulfillment",
+		"rates_package":      "package",
+		"recipe":             "recipes",
+		"setups":             "processSetups",
+		"labor":              "labor",
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if k == "ink_markup" {
+			out["ink"] = map[string]any{"markup": v}
+			continue
+		}
+		if alias, ok := aliases[k]; ok {
+			out[alias] = v
+			continue
+		}
+		out[k] = v
 	}
 	return out
 }

--- a/artdrop/studio/pricing/quote_test.go
+++ b/artdrop/studio/pricing/quote_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,15 +12,44 @@ import (
 )
 
 // mongoDataFromVariables builds a Mongo-style flat Data map from the embedded
-// variables.json. This mirrors what PricingStore.GetActive produces: the rates
-// as top-level keys of the document.
+// variables.json, using the real Payload CMS key names that PricingStore
+// GetActive produces (printing, presentation, ..., recipes, processSetups) and
+// the nested ink.markup. This mirrors the actual pricing-configurations
+// document in Mongo (issue #78).
 func mongoDataFromVariables(t *testing.T) map[string]any {
 	t.Helper()
 	var variables map[string]any
 	if err := json.Unmarshal(defaultVariablesJSON, &variables); err != nil {
 		t.Fatalf("unmarshal variables.json: %v", err)
 	}
-	return variables
+
+	// Translate the internal engine key names back to the Payload CMS key
+	// names that LoadDataFromMap expects (the inverse of mongoKeyAliases),
+	// and nest ink_markup under ink.markup.
+	aliases := map[string]string{
+		"rates_printing":     "printing",
+		"rates_presentation": "presentation",
+		"rates_cutting":      "cutting",
+		"rates_fulfillment":  "fulfillment",
+		"rates_package":      "package",
+		"recipe":             "recipes",
+		"setups":             "processSetups",
+		"labor":              "labor",
+	}
+
+	mongo := make(map[string]any, len(variables))
+	for k, v := range variables {
+		if k == "ink_markup" {
+			mongo["ink"] = map[string]any{"markup": v}
+			continue
+		}
+		if alias, ok := aliases[k]; ok {
+			mongo[alias] = v
+			continue
+		}
+		mongo[k] = v
+	}
+	return mongo
 }
 
 func quoteActiveConfig(updatedAt time.Time, data map[string]any) *datastoremongo.PricingConfiguration {
@@ -100,8 +130,9 @@ func TestQuoteHashChangesWhenRatesChange(t *testing.T) {
 		t.Fatalf("quoteHash returned error: %v", err)
 	}
 
-	// Mutate a rate and confirm the hash changes.
-	rates := data["rates_printing"].(map[string]any)
+	// Mutate a rate and confirm the hash changes. data is Mongo-shaped, so the
+	// rate category is keyed by the Payload CMS name "printing".
+	rates := data["printing"].(map[string]any)
 	rates["mach_cmin"] = 9.999
 
 	changed, err := quoteHash(data)
@@ -261,4 +292,92 @@ func TestQuoteServiceFromMapMatchesSpreadsheetGroundTruth(t *testing.T) {
 	}
 
 	money(t, "grand_total_1pc", res.GrandTotal1PC, 250.0616296302498)
+}
+
+// TestNormalizeMongoData verifies the Payload CMS -> internal engine key
+// translation and the ink.markup unwrap that LoadDataFromMap relies on (issue
+// #78). It asserts that a Mongo-shaped map (printing, ..., ink.markup, recipes,
+// processSetups) normalizes to the internal engine key names (rates_printing,
+// ..., ink_markup, recipe, setups) that LoadData reads from variables.json.
+func TestNormalizeMongoData(t *testing.T) {
+	mongo := mongoDataFromVariables(t)
+
+	normalized, err := normalizeMongoData(mongo)
+	if err != nil {
+		t.Fatalf("normalizeMongoData returned error: %v", err)
+	}
+
+	// The internal engine keys must be present after translation.
+	for _, internal := range []string{
+		"rates_printing", "rates_presentation", "rates_cutting",
+		"rates_fulfillment", "rates_package", "ink_markup",
+		"labor", "recipe", "setups",
+	} {
+		if _, ok := normalized[internal]; !ok {
+			t.Errorf("normalized map missing internal key %q", internal)
+		}
+	}
+
+	// ink.markup must be unwrapped to the flat ink_markup number.
+	inkMk, ok := normalized["ink_markup"]
+	if !ok {
+		t.Fatal("normalized map missing ink_markup")
+	}
+	if _, isNum := inkMk.(float64); !isNum {
+		t.Errorf("ink_markup should be a flat number, got %T", inkMk)
+	}
+
+	// The Payload CMS keys must no longer be present (they were translated).
+	for _, cms := range []string{
+		"printing", "presentation", "cutting", "fulfillment",
+		"package", "ink", "recipes", "processSetups",
+	} {
+		if _, ok := normalized[cms]; ok {
+			t.Errorf("normalized map still contains Payload CMS key %q", cms)
+		}
+	}
+}
+
+// TestNormalizeMongoDataMissingKey verifies that normalizeMongoData rejects a
+// Mongo map that is missing any required Payload CMS key, naming the missing
+// key in the error.
+func TestNormalizeMongoDataMissingKey(t *testing.T) {
+	mongo := mongoDataFromVariables(t)
+
+	for _, missing := range []string{
+		"printing", "presentation", "cutting", "fulfillment",
+		"package", "ink", "labor", "recipes", "processSetups",
+	} {
+		t.Run(missing, func(t *testing.T) {
+			m := make(map[string]any, len(mongo))
+			for k, v := range mongo {
+				if k == missing {
+					continue
+				}
+				m[k] = v
+			}
+			_, err := normalizeMongoData(m)
+			if err == nil {
+				t.Fatalf("expected error when %q is missing", missing)
+			}
+			if !strings.Contains(err.Error(), missing) {
+				t.Errorf("error %q should name the missing key %q", err, missing)
+			}
+		})
+	}
+}
+
+// TestNormalizeMongoDataInkNotObject verifies that an ink key that is not an
+// object (e.g. a flat number) is rejected with a clear error.
+func TestNormalizeMongoDataInkNotObject(t *testing.T) {
+	mongo := mongoDataFromVariables(t)
+	mongo["ink"] = 2.0
+
+	_, err := normalizeMongoData(mongo)
+	if err == nil {
+		t.Fatal("expected error when ink is not an object")
+	}
+	if !strings.Contains(err.Error(), "ink") {
+		t.Errorf("error %q should mention ink", err)
+	}
 }


### PR DESCRIPTION
## Qué cambia

Alinea **`LoadDataFromMap`** (issue #78) con el esquema real que Payload CMS guarda en `pricing-configurations` (domain `studio-printing`). Hoy el endpoint `POST /v1/studio/quotes:price` contra la Mongo real daba 500 (`pricing data missing required key "rates_printing"`) porque el bridge esperaba claves internas (`rates_printing`, ...) que no existen en Mongo.

### Traducción de claves Payload CMS → motor
- **`artdrop/studio/pricing/from_map.go`**:
  - `requiredRateKeys` ahora valida las claves reales de Mongo (`printing`, `presentation`, `cutting`, `fulfillment`, `package`, `ink`, `labor`, `recipes`, `processSetups`).
  - `mongoKeyAliases` traduce las claves de nivel superior al nombre interno del motor (`printing` → `rates_printing`, `recipes` → `recipe`, `processSetups` → `setups`, etc.).
  - `normalizeMongoData` valida presencia de las claves, traduce los alias y **unwrap** `ink.markup` → `ink_markup` (número plano). El contenido interno de cada categoría coincide campo por campo, así que solo cambia el nombre de la clave de nivel superior.

### Tests
- **`quote_test.go`**: `mongoDataFromVariables` ahora produce el esquema real de Mongo (claves Payload CMS + `ink.markup` anidado). Nuevos tests:
  - `TestNormalizeMongoData`: verifica la traducción de las 8 claves + el unwrap de `ink.markup`.
  - `TestNormalizeMongoDataMissingKey`: rechaza un mapa que falte cualquier clave requerida, nombrando la clave en el error.
  - `TestNormalizeMongoDataInkNotObject`: rechaza `ink` que no sea objeto.
  - `TestQuoteHashChangesWhenRatesChange` ajustado a la clave real `printing`.
- **`from_map_fuzz_test.go`**: `FuzzLoadDataFromMap` ahora siembra con claves Payload CMS (vía `internalToMongoKeys`, inversa de `normalizeMongoData`) y muta `printing.bed_gap` / `printing.min_order`.

## Verdict `go test ./...`
- `go build`, `go vet` y `gofmt` limpios.
- `go test ./artdrop/studio/pricing/...` OK (incluye los nuevos tests de traducción/unwrap y el ground-truth de spreadsheet).

Closes #78