### PR TITLE
78: normalize BSON-decoded pricing data to plain Go types

### DIFF
--- a/artdrop/studio/pricing/bson_chain_test.go
+++ b/artdrop/studio/pricing/bson_chain_test.go
@@ -1,0 +1,177 @@
+package pricing
+
+import (
+	"testing"
+
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestBSONDataNormalizesAndRunsThroughFullChain is the live regression test
+// for the deeper bug reopened on issue #78 after PR #79 landed. PR #79
+// translated the Payload CMS top-level key names, but testing against a real
+// running Mongo-backed service revealed a follow-on type-mismatch bug: the
+// Mongo driver decodes nested documents as primitive.M (a named type
+// distinct from map[string]interface{} even though the same underlying
+// type), arrays as primitive.A, and integers as int32/int64. The pricing
+// helpers (object/array/num in pricing.go) and normalizeMongoData (in
+// from_map.go, PR #79) type-switch on plain Go types only, so passing the
+// raw primitive.M/primitive.A/int32 values through would either silently
+// degrade to zeros (because the helpers' default branches return zero/empty)
+// or, for normalizeMongoData's ink.type check, fail loudly with "pricing
+// data key ink must be an object".
+//
+// NormalizeBSONData (datastore/mongo/store.go) closes this gap by JSON
+// round-tripping bson-decoded data into plain Go types. This test exercises
+// the full chain — primitive.BSON-shaped data through
+// datastoremongo.NormalizeBSONData → LoadDataFromMap → Compute — and asserts
+// no error and a sane positive GrandTotal1PC. No real Mongo connection is
+// required; we construct primitive.M / primitive.A / int32 directly.
+func TestBSONDataNormalizesAndRunsThroughFullChain(t *testing.T) {
+	raw := bson.M{
+		"printing": bson.M{
+			"mach_cmin":       float64(1.636),
+			"press_mk":        float64(5.0916870416),
+			"press_hr_day":    int32(7),
+			"press_setup_min": int32(5),
+			"bed_disc":        float64(0.05),
+			"disc_per_bed":    float64(0.05),
+			"disc_max":        float64(0.25),
+			"bed_speed":       float64(0.3),
+			"bed_w":           int32(126),
+			"bed_l":           int32(79),
+			"bed_gap":         int32(2),
+			"bed_maxw":        int32(120),
+			"min_order":       int32(150),
+			"rush_pct":        int32(1),
+			"reprint_pct":     float64(0.05),
+			"mm_per_layer":    float64(0.16),
+			"varnish_tbl":     bson.M{"No Gloss": int32(0), "Matte": int32(1), "Semi-Gloss": int32(2), "Hi Gloss": int32(3)},
+		},
+		"presentation": bson.M{
+			"pm_waste":        float64(0.2),
+			"pm_setup":        int32(5),
+			"pm_lab":          float64(1.5),
+			"pf_mat":          "Aluminum Frame Strip",
+			"pf_tape":         "Framing Tape",
+			"pf_waste":        float64(0.1),
+			"pf_inset":        int32(2),
+			"pf_corner":       "Push Corner",
+			"pf_cornerqty":    int32(4),
+			"pf_setup":        int32(5),
+			"pf_lab":          float64(1.5),
+			"ps_waste":        float64(0.1),
+			"ps_setup":        int32(5),
+			"ps_lab":          int32(2),
+			"fold_mult":       int32(2),
+			"cross_threshold": int32(40),
+			"pl_corner":       "Frame Corner Join",
+			"pl_cornerqty":    int32(4),
+			"pl_clip":         "Float Mount Clip",
+			"pl_clipqty":      int32(4),
+			"pl_waste":        float64(0.12),
+			"pl_setup":        int32(6),
+			"pl_lab":          int32(2),
+		},
+		"cutting": bson.M{
+			"cnc_hr":     float64(150),
+			"cnc_mk":     float64(1.5),
+			"cnc_setup":  int32(5),
+			"cnc_secin":  float64(1),
+			"hand_setup": int32(2),
+			"hand_secin": int32(2),
+		},
+		"fulfillment": bson.M{
+			"ff_bulk_min":    int32(1),
+			"ff_pickup_min":  int32(5),
+			"ff_drop_min":    int32(5),
+			"sign_unbox_min": int32(2),
+		},
+		"package": bson.M{
+			"card_mat":          "Double-wall Cardboard",
+			"craft_mat":         "Craft Tape",
+			"strap_mat":         "Strapping Tape",
+			"glassine_mat":      "Glassine Roll",
+			"wrap_mat":          "Bubble Wrap",
+			"packtape_mat":      "Packing Tape",
+			"artist_mat":        "Artist Tape",
+			"pk_custom_border":  int32(3),
+			"pk_custom_card":    int32(3),
+			"pk_custom_wrap":    int32(2),
+			"pk_custom_craft":   int32(2),
+			"pk_custom_strap":   float64(0.25),
+			"pk_custom_packtape": float64(0.25),
+			"pk_custom_glas":    int32(2),
+			"pk_custom_setup":   int32(10),
+			"pk_custom_lab":     int32(5),
+			"pk_custom_artist":  int32(1),
+			"pk_pack_border":    int32(2),
+			"pk_pack_card":      int32(4),
+			"pk_pack_craft":     int32(1),
+			"pk_pack_strap":     int32(0),
+			"pk_pack_packtape":  float64(0.25),
+			"pk_pack_glas":      int32(2),
+			"pk_pack_setup":     int32(5),
+			"pk_pack_lab":       int32(5),
+			"pk_pack_artist":    int32(1),
+		},
+		"ink": bson.M{"markup": int32(2)},
+		"labor": bson.M{
+			"production": bson.M{"hourly": float64(30), "markup": float64(2.5)},
+			"handling":   bson.M{"hourly": int32(20), "markup": int32(2)},
+			"creative":   bson.M{"hourly": int32(50), "markup": float64(2)},
+		},
+		"recipes": bson.A{
+			bson.M{
+				"process":      "Metal Print",
+				"comp100":      int32(1),
+				"comp200":      int32(0),
+				"white420":     int32(0),
+				"whiteflood":   int32(0),
+				"white100":     int32(0),
+				"color":        int32(0),
+				"varnish":      int32(1),
+				"texture_grid": "None",
+			},
+		},
+		"processSetups": bson.M{"Metal Print": int32(100)},
+	}
+
+	normalized, err := datastoremongo.NormalizeBSONData(raw)
+	if err != nil {
+		t.Fatalf("NormalizeBSONData: %v", err)
+	}
+
+	data, err := LoadDataFromMap(normalized)
+	if err != nil {
+		t.Fatalf("LoadDataFromMap: %v", err)
+	}
+
+	cfg := Config{
+		Process:    "Metal Print",
+		Shape:      "Rectangle",
+		W:          20,
+		L:          30,
+		Matcat:     "Canvas",
+		Media:      "Aurora Linen Canvas",
+		Preset:     "Flat",
+		Varnish:    "Matte",
+		Present:    "Media only",
+		MountPanel: "MaxMetal ACM Panel",
+		BarType:    "Stretcher Bar Gallery 1.5in",
+		Edge:       "Mirror",
+		Moulding:   "Floater Black 1.5in",
+		Fulfill:    "Bulk to artist",
+		Pack:       "Flat Pack",
+		Rush:       "No",
+		RunSize:    10,
+	}
+
+	res, err := Compute(data, cfg)
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if res.GrandTotal1PC <= 0 {
+		t.Fatalf("expected positive GrandTotal1PC, got %v", res.GrandTotal1PC)
+	}
+}

--- a/datastore/mongo/mongo_test.go
+++ b/datastore/mongo/mongo_test.go
@@ -219,3 +219,53 @@ func assertFindSortsByEffectiveFromDesc(t *mtest.T) {
 		t.Fatalf("expected sort.effectiveFrom -1, got %d in command %s", got, event.Command)
 	}
 }
+
+// TestNormalizeBSONDataProducesPlainGoTypes reproduces the type-mismatch bug
+// found live against a real Mongo-backed QuoteService. The mongo driver
+// decodes nested objects as primitive.M (a named type distinct from
+// map[string]interface{} even though the same underlying type), arrays as
+// primitive.A, and integers as int32/int64. The pricing helpers
+// (object/array/num in pricing.go) and normalizeMongoData (in from_map.go,
+// added in PR #79) type-switch on plain Go types only, so a raw primitive.M
+// would have silently degraded to zeros (except for the loud ink.type check
+// in normalizeMongoData). NormalizeBSONData flattens this to genuine plain
+// Go types via a json.Marshal / json.Unmarshal round-trip.
+func TestNormalizeBSONDataProducesPlainGoTypes(t *testing.T) {
+	raw := bson.M{
+		"obj":   bson.M{"markup": int32(2)},
+		"arr":   bson.A{int32(1), int32(2), int32(3)},
+		"plain": int32(42),
+	}
+
+	got, err := NormalizeBSONData(raw)
+	if err != nil {
+		t.Fatalf("NormalizeBSONData: %v", err)
+	}
+
+	// Top-level type must be map[string]any (the named type bson.M becomes the
+	// underlying map type via JSON round-trip).
+	if _, ok := got["obj"].(map[string]any); !ok {
+		t.Fatalf("got[obj] type = %T, want map[string]any", got["obj"])
+	}
+
+	// Nested int32 → float64 (pricing.go's num() helper returns float64).
+	nestedMap, ok := got["obj"].(map[string]any)
+	if !ok {
+		t.Fatalf("got[obj] not map[string]any")
+	}
+	v, ok := nestedMap["markup"].(float64)
+	if !ok || v != 2 {
+		t.Fatalf("got[obj][markup] = %v (%T), want float64 2", nestedMap["markup"], nestedMap["markup"])
+	}
+
+	// primitive.A → []interface{} (NOT primitive.A; pricing.go's array()
+	// helper only matches []interface{}).
+	if _, ok := got["arr"].([]interface{}); !ok {
+		t.Fatalf("got[arr] type = %T, want []interface{}", got["arr"])
+	}
+
+	// Plain int32 → float64 (matching pricing.go's num() float64-only contract).
+	if v, ok := got["plain"].(float64); !ok || v != 42 {
+		t.Fatalf("got[plain] = %v (%T), want float64 42", got["plain"], got["plain"])
+	}
+}

--- a/datastore/mongo/store.go
+++ b/datastore/mongo/store.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -110,9 +111,50 @@ func (s *PricingStore) GetActive(ctx context.Context) (*PricingConfiguration, er
 	for _, key := range []string{"_id", "domain", "status", "effectiveFrom", "updatedAt"} {
 		delete(full, key)
 	}
-	cfg.Data = full
+	// The Mongo driver decodes embedded objects as primitive.M (a named type
+	// distinct from map[string]interface{} even though the same underlying type),
+	// arrays as primitive.A, and numbers as int32/int64 depending on the source
+	// document. The downstream pricing helpers (object/array/num in pricing.go)
+	// and normalizeMongoData (in from_map.go, added in PR #79) type-switch on
+	// plain Go types only, so passing primitive.M/primitive.A/int32 through
+	// would silently degrade to zeros (except the ink.type check in
+	// normalizeMongoData, which fails loudly first). Normalize to genuine
+	// map[string]interface{} / []interface{} / float64 / string here.
+	normalized, err := NormalizeBSONData(full)
+	if err != nil {
+		return nil, fmt.Errorf("normalize bson data: %w", err)
+	}
+	cfg.Data = normalized
 
 	return &cfg, nil
+}
+
+// NormalizeBSONData converts a bson.M (the data portion of a pricing-
+// configuration document) into plain JSON-compatible Go types so downstream
+// code receives genuine map[string]any / []interface{} / float64 / string
+// values regardless of which BSON named types the mongo driver produced.
+//
+// The conversion is done via json.Marshal + json.Unmarshal round-trip which is
+// sufficient: every BSON scalar type we use (string, int32, int64, float64,
+// bool) encodes to a JSON value that decodes back to the plain Go type the
+// pricing helpers expect (string stays string, all numbers become float64,
+// bool stays bool). Nested documents and arrays recursively yield plain map/
+// slice types.
+//
+// Exported so the pricing package (which already imports datastore/mongo for
+// other reasons) can unit-test that primitive.BSON-shaped data round-trips
+// through NormalizeBSONData and then feeds LoadDataFromMap and Compute
+// without errors or silent degradation to zeros.
+func NormalizeBSONData(full bson.M) (map[string]any, error) {
+	data, err := json.Marshal(full)
+	if err != nil {
+		return nil, fmt.Errorf("marshal bson data for normalization: %w", err)
+	}
+	var normalized map[string]any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return nil, fmt.Errorf("unmarshal normalized bson data: %w", err)
+	}
+	return normalized, nil
 }
 
 // GetActiveUpdatedAt returns the updatedAt of the active Studio printing


### PR DESCRIPTION
Closes #78 (reopened). El fix de #79 tradujo bien los nombres de clave, pero probar el endpoint real contra Mongo reveló un problema más profundo: el driver decodifica objetos anidados como `primitive.M`, arrays como `primitive.A` y enteros como `int32`/`int64` — tipos distintos a los que `object()`/`array()`/`num()` en `pricing.go` esperan (`map[string]any`/`[]any`/`float64`/`int`). Sin este fix, esos helpers degradan en silencio a `{}`/`nil`/`0` en vez de fallar, salvo el chequeo de `ink` en `normalizeMongoData` que por casualidad falla ruidoso primero.

Agrega `NormalizeBSONData` en `datastore/mongo`, que convierte el `bson.M` leído en `GetActive` a tipos JSON planos (round-trip `json.Marshal`/`Unmarshal`) antes de que llegue a `cfg.Data`. Dos tests nuevos reproducen el bug sin necesitar Mongo real: uno aislado con `primitive.M`/`primitive.A`/`int32` directos, y otro que corre la cadena completa (`NormalizeBSONData` → `LoadDataFromMap` → `Compute`) con un documento con la forma exacta del real.

16 paquetes en verde (`go build`/`go vet` limpios). Los 2 que fallan (`tests`, root) son pre-existentes, confirmados igual en `main` limpio — necesitan un nodo Flow real, no relacionados con este cambio.