### PR TITLE
330: look up studio quotes by publicToken instead of id

### DIFF
--- a/datastore/mongo/quote_store.go
+++ b/datastore/mongo/quote_store.go
@@ -20,7 +20,11 @@ var ErrQuoteNotFound = errors.New("studio quote not found")
 // what the charge flow (#71) translates into a pricing.Config to recalculate
 // the exact price at charge time.
 type StudioQuote struct {
-	ID     string         `bson:"id" json:"id"`
+	// ID is the stable public token (publicToken) that Payload CMS assigns to
+	// a studio quote. Payload persists the quote with an ObjectId _id and no
+	// "id" field; the public token is the only stable, externally-addressable
+	// identity, so lookups key on it.
+	ID     string         `bson:"publicToken" json:"publicToken"`
 	UserID string         `bson:"userId" json:"userId"`
 	// Config holds the Studio Wizard config snapshot (process, W, L, borders,
 	// run_size, ...) as stored by Payload CMS. It is the input to the pricing
@@ -46,8 +50,8 @@ func NewQuoteStore(client *Client, cfg *configs.Config) *QuoteStore {
 	}
 }
 
-// GetByID returns the studio quote document matching the given quote id. It
-// returns ErrQuoteNotFound when no such quote exists.
+// GetByID returns the studio quote document matching the given public token
+// (publicToken). It returns ErrQuoteNotFound when no such quote exists.
 func (s *QuoteStore) GetByID(ctx context.Context, quoteID string) (*StudioQuote, error) {
 	if s == nil || s.client == nil {
 		return nil, fmt.Errorf("mongo client is not configured")
@@ -57,7 +61,7 @@ func (s *QuoteStore) GetByID(ctx context.Context, quoteID string) (*StudioQuote,
 	}
 
 	var raw bson.Raw
-	err := s.client.Collection(s.coll).FindOne(ctx, bson.M{"id": quoteID}).Decode(&raw)
+	err := s.client.Collection(s.coll).FindOne(ctx, bson.M{"publicToken": quoteID}).Decode(&raw)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrQuoteNotFound


### PR DESCRIPTION
## Contexto

Desbloquea el flujo de compra end-to-end de `4rtdr0p/Payload-Galaxy#330` (ruta de compra como proxy al endpoint de Go). El comentario del issue #330 (dependencia cross-repo) pide exactamente este cambio:

> El repo Go `4rtdr0p/flow-accounts-manager` debe cambiar su `QuoteStore.GetByID` en `datastore/mongo/quote_store.go` para consultar por `publicToken` en lugar de `id` (`bson.M{"publicToken": quoteID}` y `StudioQuote.ID bson:"publicToken"`).

## Problema

Payload persiste `studio-quotes` con `_id` (ObjectId) y **no** tiene campo `id` en el documento guardado; el rename `_id → id` ocurre solo en la capa de lectura. La ruta de Payload ahora envía `quote.publicToken` (UUID estable) como `QuoteID`, pero `QuoteStore.GetByID` consultaba `bson.M{"id": quoteID}` — un campo que **no existe** en el documento persistido. El lookup nunca coincidía → siempre `ErrQuoteNotFound` (404). El flujo de compra estaba roto de punta a punta.

## Cambio

- [`datastore/mongo/quote_store.go`](datastore/mongo/quote_store.go): `GetByID` ahora consulta `bson.M{"publicToken": quoteID}`.
- `StudioQuote.ID` mapea al campo `publicToken` (`bson:"publicToken"`).

## Verificación

- `go build ./...` → OK.
- `go vet ./datastore/... ./studio/...` → limpio.
- `go test ./datastore/... ./studio/...` → **ok** (con `CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"`

Closes 4rtdr0p/Payload-Galaxy#330 (bloqueante cross-repo).