### PR TITLE
Add re-escrow route: reopen an escrow on an existing certificate

### DIFF
--- a/artdrop/cdc/re_escrow.cdc
+++ b/artdrop/cdc/re_escrow.cdc
@@ -1,0 +1,53 @@
+/// re_escrow.cdc — Protocol crea un nuevo escrow sobre un Certificate YA
+/// minteado ([SECURITY] issue #175 / diseño de re-escrow sin huérfanos).
+///
+/// Cierra el hueco del timeout normal: cuando el buyer nunca reclama, el
+/// escrow expira, el 5% vuelve, y el certificado queda varado con el
+/// seller para siempre — la única forma de re-vender esa pieza era
+/// create_escrow.cdc, que siempre mintea un certificado NUEVO. Este
+/// transaction reutiliza el certificado existente sin mintear nada.
+///
+/// certificateId reemplaza editionId — el contrato deriva editionId del
+/// certificado mismo, nunca del caller.
+
+import FungibleToken from 0x9a0766d93b6608b7
+import ArtDropCore from 0xec581a0282d99a1a
+import EscrowModule from 0x1bfedfa0ec66c23e
+
+transaction(
+    logicOwner: Address,
+    buyer: Address,
+    seller: Address,
+    certificateId: UInt64,
+    chipId: String,
+    unlockAt: UFix64,
+    nonce: UInt64,
+    amount: UFix64,
+    vaultIdentifier: String
+) {
+    prepare(signer: auth(BorrowValue, FungibleToken.Withdraw) &Account) {
+        let vaultPath = StoragePath(identifier: vaultIdentifier)!
+        let vault = signer.storage.borrow<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(
+            from: vaultPath
+        ) ?? panic("re_escrow: vault not found at path")
+
+        let payment <- vault.withdraw(amount: amount)
+
+        let escrowLogic = getAccount(logicOwner)
+            .capabilities
+            .borrow<&{EscrowModule.IEscrowLogic}>(EscrowModule.PublicPath)
+            ?? panic("re_escrow: EscrowModule capability missing")
+
+        let escrowId = escrowLogic.createReEscrow(
+            buyer: buyer,
+            seller: seller,
+            certificateId: certificateId,
+            chipId: chipId,
+            unlockAt: unlockAt,
+            nonce: nonce,
+            payment: <-payment
+        )
+
+        log("Re-escrow created with id: ".concat(escrowId.toString()))
+    }
+}

--- a/artdrop/cdc_test.go
+++ b/artdrop/cdc_test.go
@@ -17,6 +17,7 @@ func embeddedCDCScripts() map[string]string {
 		"get_certificates.cdc":              getCertificatesCDC,
 		"get_escrow_summary.cdc":            getEscrowSummaryCDC,
 		"create_escrow.cdc":                 createEscrowCDC,
+		"re_escrow.cdc":                     reEscrowCDC,
 		"activate_chip_and_settle.cdc":      activateChipAndSettleCDC,
 		"get_original_extended_summary.cdc": getOriginalExtendedSummaryCDC,
 		"get_edition_summary.cdc":           getEditionSummaryCDC,

--- a/artdrop/handler.go
+++ b/artdrop/handler.go
@@ -232,6 +232,26 @@ func (h *Handler) CreateEscrowFunc(rw http.ResponseWriter, r *http.Request) {
 	h.handleTransactionResponse(rw, sync, job, tx)
 }
 
+func (h *Handler) ReEscrow() http.Handler {
+	return handlers.UseJson(http.HandlerFunc(h.ReEscrowFunc))
+}
+
+func (h *Handler) ReEscrowFunc(rw http.ResponseWriter, r *http.Request) {
+	var req ReEscrowRequest
+	if !h.decodeBody(rw, r, &req) {
+		return
+	}
+
+	sync := r.FormValue(handlers.SyncQueryParameter) != ""
+	job, tx, err := h.svc.ReEscrow(r.Context(), sync, mux.Vars(r)["address"], req)
+	if err != nil {
+		handlers.HandleError(rw, r, err)
+		return
+	}
+
+	h.handleTransactionResponse(rw, sync, job, tx)
+}
+
 func (h *Handler) ActivateChip() http.Handler {
 	return handlers.UseJson(http.HandlerFunc(h.ActivateChipFunc))
 }

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -60,6 +60,7 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	router.Handle("/accounts/{artistAddress}/artdrop/originals", h.CreateOriginal()).Methods(http.MethodPost)
 	router.Handle("/accounts/{artistAddress}/artdrop/originals/{originalId}/editions", h.CreateEdition()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows", h.CreateEscrow()).Methods(http.MethodPost)
+	router.Handle("/accounts/{address}/artdrop/escrows/re-escrow", h.ReEscrow()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate", h.ActivateChip()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate-chip", h.ActivateChip()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/escrows/{escrowId}/activate-and-settle", h.ActivateChip()).Methods(http.MethodPost)

--- a/artdrop/service.go
+++ b/artdrop/service.go
@@ -35,6 +35,9 @@ var getEscrowSummaryCDC string
 //go:embed cdc/create_escrow.cdc
 var createEscrowCDC string
 
+//go:embed cdc/re_escrow.cdc
+var reEscrowCDC string
+
 //go:embed cdc/activate_chip_and_settle.cdc
 var activateChipAndSettleCDC string
 
@@ -88,6 +91,7 @@ type Service struct {
 	getCertificatesCDC            string
 	getEscrowSummaryCDC           string
 	createEscrowCDC               string
+	reEscrowCDC                   string
 	activateChipAndSettleCDC      string
 	getOriginalExtendedSummaryCDC string
 	getEditionSummaryCDC          string
@@ -129,6 +133,7 @@ func NewService(deps plugins.PluginDeps, cfg *Config) (*Service, error) {
 		getCertificatesCDC:            sub(getCertificatesCDC),
 		getEscrowSummaryCDC:           sub(getEscrowSummaryCDC),
 		createEscrowCDC:               sub(createEscrowCDC),
+		reEscrowCDC:                   sub(reEscrowCDC),
 		activateChipAndSettleCDC:      sub(activateChipAndSettleCDC),
 		getOriginalExtendedSummaryCDC: sub(getOriginalExtendedSummaryCDC),
 		getEditionSummaryCDC:          sub(getEditionSummaryCDC),
@@ -375,6 +380,56 @@ func (s *Service) CreateEscrow(ctx context.Context, sync bool, address string, r
 	}
 
 	return s.deps.Transactions.Create(ctx, sync, proposerAddress, s.createEscrowCDC, args, TxTypeCreateEscrow)
+}
+
+// ReEscrow opens a new escrow against an EXISTING, already-minted
+// certificate ([SECURITY] issue #175 / no-orphans re-escrow design) — no
+// mint. Mirrors CreateEscrow's server-controlled-argument discipline
+// exactly: proposerAddress/logicOwner and vaultIdentifier come from
+// s.deps.Config/defaultVaultIdentifier, never the request body.
+func (s *Service) ReEscrow(ctx context.Context, sync bool, address string, req ReEscrowRequest) (*jobs.Job, *transactions.Transaction, error) {
+	if _, err := flow_helpers.ValidateAddress(address, s.deps.Config.ChainID); err != nil {
+		return nil, nil, err
+	}
+
+	proposerAddress, err := flow_helpers.ValidateAddress(s.deps.Config.AdminAddress, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate admin address: %w", err)
+	}
+
+	buyer, err := flow_helpers.ValidateAddress(req.Buyer, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	seller, err := flow_helpers.ValidateAddress(req.Seller, s.deps.Config.ChainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	unlockAt, err := newUFix64(req.UnlockAt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'unlock_at': %w", err)
+	}
+	amount, err := newUFix64(req.Amount)
+	if err != nil {
+		return nil, nil, fmt.Errorf("field 'amount': %w", err)
+	}
+	if req.ChipId == "" {
+		return nil, nil, fmt.Errorf("field 'chip_id' is required")
+	}
+
+	args := []transactions.Argument{
+		cadence.NewAddress(flow.HexToAddress(s.cfg.LogicOwner)),
+		cadence.NewAddress(flow.HexToAddress(buyer)),
+		cadence.NewAddress(flow.HexToAddress(seller)),
+		cadence.NewUInt64(req.CertificateId),
+		cadence.String(req.ChipId),
+		unlockAt,
+		cadence.NewUInt64(req.Nonce),
+		amount,
+		cadence.String(defaultVaultIdentifier),
+	}
+
+	return s.deps.Transactions.Create(ctx, sync, proposerAddress, s.reEscrowCDC, args, TxTypeReEscrow)
 }
 
 // ActivateChip validates a chip signature and settles the escrow.

--- a/artdrop/service_test.go
+++ b/artdrop/service_test.go
@@ -415,6 +415,69 @@ func TestServiceCreateEscrowSendsNoChipPublicKey(t *testing.T) {
 	}
 }
 
+// TestServiceReEscrowUsesAdminProposerAndCadenceArgs pins the request shape
+// for ReEscrow the same way TestServiceCreateEscrowUsesAdminProposerAndCadenceArgs
+// pins CreateEscrow's — server-controlled logicOwner/vaultIdentifier,
+// certificateId (not editionId) at the position the contract expects, so a
+// future edit can't silently reintroduce a client-supplied logicOwner,
+// vaultIdentifier, or editionId field.
+func TestServiceReEscrowUsesAdminProposerAndCadenceArgs(t *testing.T) {
+	txSvc := &setupTxService{}
+	cfg := ParseTestConfig(t)
+	svc, err := NewService(plugins.PluginDeps{
+		Transactions: txSvc,
+		Config: &configs.Config{
+			AdminAddress: "0xf8d6e0586b0a20c7",
+			ChainID:      flow.Emulator,
+		},
+	}, cfg)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, _, err = svc.ReEscrow(context.Background(), true, "0xf8d6e0586b0a20c7", ReEscrowRequest{
+		Buyer:         "0xf8d6e0586b0a20c7",
+		Seller:        "0x0ae53cb6e3f42a79",
+		CertificateId: 7,
+		ChipId:        "chip-1",
+		UnlockAt:      123.45,
+		Nonce:         7,
+		Amount:        10.5,
+	})
+	if err != nil {
+		t.Fatalf("ReEscrow returned error: %v", err)
+	}
+
+	if len(txSvc.calls) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txSvc.calls))
+	}
+	call := txSvc.calls[0]
+	if call.proposerAddress != "0xf8d6e0586b0a20c7" {
+		t.Fatalf("expected admin proposer, got %q", call.proposerAddress)
+	}
+	if call.txType != TxTypeReEscrow {
+		t.Fatalf("expected type %q, got %q", TxTypeReEscrow, call.txType)
+	}
+	if !strings.Contains(call.code, "createReEscrow") {
+		t.Fatal("expected re-escrow CDC")
+	}
+	if len(call.args) != 9 {
+		t.Fatalf("expected 9 args, got %d", len(call.args))
+	}
+	if got := call.args[0]; got != cadence.NewAddress(flow.HexToAddress(cfg.LogicOwner)) {
+		t.Fatalf("expected logicOwner arg to be server config's %q, got %#v", cfg.LogicOwner, got)
+	}
+	if got := call.args[3]; got != cadence.NewUInt64(7) {
+		t.Fatalf("expected certificateId arg 7, got %#v", got)
+	}
+	if got := call.args[4]; got != cadence.String("chip-1") {
+		t.Fatalf("expected chipId arg, got %#v", got)
+	}
+	if got := call.args[8]; got != cadence.String(defaultVaultIdentifier) {
+		t.Fatalf("expected vaultIdentifier arg %q, got %#v", defaultVaultIdentifier, got)
+	}
+}
+
 // TestServiceActivateChipUsesPathAddressAndServerLogicOwner also covers the
 // removal of ActivateChipRequest.LogicOwner, .CertificateId and
 // .CertificateOwner (escrow-lifecycle redesign, 2026-08 — the contract now

--- a/artdrop/types.go
+++ b/artdrop/types.go
@@ -15,6 +15,7 @@ const (
 	TxTypeSetup             transactions.Type = "ArtdropSetup"
 	TxTypeTransfer          transactions.Type = "ArtdropTransfer"
 	TxTypeCreateEscrow      transactions.Type = "ArtdropCreateEscrow"
+	TxTypeReEscrow          transactions.Type = "ArtdropReEscrow"
 	TxTypeActivateChip      transactions.Type = "ArtdropActivateChip"
 	TxTypeSetupArtistDirect transactions.Type = "ArtdropSetupArtistDirect"
 	TxTypeCreateOriginal    transactions.Type = "ArtdropCreateOriginal"
@@ -73,6 +74,31 @@ type CreateEscrowRequest struct {
 	UnlockAt  float64 `json:"unlock_at"`
 	Nonce     uint64  `json:"nonce"`
 	Amount    float64 `json:"amount"`
+}
+
+// ReEscrowRequest contains the parameters needed to open a new escrow
+// against an EXISTING, already-minted certificate ([SECURITY] issue #175 /
+// no-orphans re-escrow design). No orphaned certificate: the normal
+// unclaimed-escrow timeout path used to leave a certificate stranded with
+// the seller forever, because the only way to sell it again was
+// CreateEscrow, which always mints a NEW certificate.
+//
+// CertificateId replaces EditionId — the contract derives editionId from
+// the certificate itself. There is deliberately no EditionId field here;
+// do not add one, and do not let a caller imply which edition this is —
+// that's exactly the caller-supplied value the contract-side fix exists to
+// not trust.
+//
+// LogicOwner and VaultIdentifier are server-controlled the same way as
+// CreateEscrowRequest — see that type's doc comment.
+type ReEscrowRequest struct {
+	Buyer         string  `json:"buyer"`
+	Seller        string  `json:"seller"`
+	CertificateId uint64  `json:"certificate_id"`
+	ChipId        string  `json:"chip_id"`
+	UnlockAt      float64 `json:"unlock_at"`
+	Nonce         uint64  `json:"nonce"`
+	Amount        float64 `json:"amount"`
 }
 
 // ActivateChipRequest contains the parameters needed to activate a chip and


### PR DESCRIPTION
## Summary

Wallet API surface for the protocol's no-orphans re-escrow design (artdrop-protocol [SECURITY] issue #175, follow-up issue #176): a new `POST /accounts/{address}/artdrop/escrows/re-escrow` route that opens a new escrow against an EXISTING, already-minted certificate — no mint. Without this route the new protocol capability was unreachable from the platform; every stranded (unclaimed, timed-out) certificate would have needed an ops CLI call to re-list.

## Changes

- `artdrop/cdc/re_escrow.cdc` — new transaction calling `EscrowModule.createReEscrow`, same shape as `create_escrow.cdc`.
- `ReEscrowRequest` (`types.go`) — mirrors `CreateEscrowRequest`'s server-controlled-argument discipline: `logic_owner` and the vault identifier come from `Config`/`defaultVaultIdentifier`, never the request body. `certificate_id` replaces `edition_id` — the contract derives the edition from the certificate itself; there is deliberately no `edition_id` field.
- `Service.ReEscrow` / `Handler.ReEscrow` — mirror `CreateEscrow`'s pair.
- New route in `plugin.go`, new `TxTypeReEscrow`.
- `re_escrow.cdc` registered in `cdc_test.go`'s embedded-script map so the address-literal test covers it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./artdrop/...` green, including new `TestServiceReEscrowUsesAdminProposerAndCadenceArgs` (pins the request shape the way `TestServiceCreateEscrowUsesAdminProposerAndCadenceArgs` does — asserts `logic_owner`/vault identifier come from config and `certificate_id` lands at the position the contract expects, so a future edit can't silently reintroduce a client-supplied `edition_id` or `logic_owner`)
- [x] `go test ./...` — the one pre-existing failure (`./tests` package, needs a live emulator) reproduces identically on `main`, unrelated to this change

## Sequencing

This does not get deployed to Quave until the protocol side (`createReEscrow`) is live-proven on testnet first.