### PR TITLE
Resolve default payment method server-side in stock-requests:create

### DIFF
--- a/studio/stripe.go
+++ b/studio/stripe.go
@@ -3,6 +3,7 @@ package studio
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,11 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrNoPaymentMethod is returned when a customer has no saved payment method
+// to resolve as a default (no invoice_settings.default_payment_method and no
+// payment methods on file).
+var ErrNoPaymentMethod = errors.New("customer has no saved payment method")
 
 // StripePaymentIntent is the subset of a Stripe PaymentIntent that the charge
 // flow needs: its id and status.
@@ -50,15 +56,22 @@ func (c *StripeClient) CreateAndConfirm(ctx context.Context, in StripeChargeInpu
 		return nil, ErrStripeDisabled
 	}
 
+	paymentMethodID := in.PaymentMethodID
+	if paymentMethodID == "" {
+		resolved, err := c.resolvePaymentMethod(ctx, in.CustomerID)
+		if err != nil {
+			return nil, err
+		}
+		paymentMethodID = resolved
+	}
+
 	form := url.Values{}
 	form.Set("amount", fmt.Sprintf("%d", in.AmountCents))
 	form.Set("currency", in.Currency)
 	form.Set("customer", in.CustomerID)
 	form.Set("confirm", "true")
 	form.Set("off_session", "true")
-	if in.PaymentMethodID != "" {
-		form.Set("payment_method", in.PaymentMethodID)
-	}
+	form.Set("payment_method", paymentMethodID)
 	form.Set("automatic_payment_methods[enabled]", "true")
 	if in.Metadata != "" {
 		form.Set("metadata[charge_ref]", in.Metadata)
@@ -79,6 +92,52 @@ func (c *StripeClient) CreateAndConfirm(ctx context.Context, in StripeChargeInpu
 		return nil, err
 	}
 	return &intent, nil
+}
+
+// resolvePaymentMethod returns the payment method to charge when the caller
+// didn't supply one explicitly: the customer's invoice_settings.default_payment_method,
+// falling back to the first payment method on file. It returns
+// ErrNoPaymentMethod if the customer has neither.
+func (c *StripeClient) resolvePaymentMethod(ctx context.Context, customerID string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/customers/"+url.PathEscape(customerID), nil)
+	if err != nil {
+		return "", fmt.Errorf("build stripe customer request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.secretKey)
+
+	var cust struct {
+		InvoiceSettings struct {
+			DefaultPaymentMethod string `json:"default_payment_method"`
+		} `json:"invoice_settings"`
+	}
+	if err := c.do(req, &cust); err != nil {
+		return "", fmt.Errorf("read stripe customer: %w", err)
+	}
+	if cust.InvoiceSettings.DefaultPaymentMethod != "" {
+		return cust.InvoiceSettings.DefaultPaymentMethod, nil
+	}
+
+	q := url.Values{}
+	q.Set("customer", customerID)
+	q.Set("type", "card")
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/payment_methods?"+q.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("build stripe payment methods request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.secretKey)
+
+	var list struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := c.do(req, &list); err != nil {
+		return "", fmt.Errorf("list stripe payment methods: %w", err)
+	}
+	if len(list.Data) == 0 {
+		return "", fmt.Errorf("%w: customer %s", ErrNoPaymentMethod, customerID)
+	}
+	return list.Data[0].ID, nil
 }
 
 // do performs a Stripe request and decodes the JSON response. A non-2xx status

--- a/studio/stripe_test.go
+++ b/studio/stripe_test.go
@@ -1,0 +1,127 @@
+package studio
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newStripeTestServer wires a mux that answers the three endpoints
+// CreateAndConfirm and resolvePaymentMethod call, returning the given
+// customer/payment-methods/payment-intent bodies. It also records the
+// payment_method form value the payment_intents call was made with.
+func newStripeTestServer(t *testing.T, customerBody, paymentMethodsBody string) (*httptest.Server, *string) {
+	t.Helper()
+	var gotPaymentMethod string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/customers/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(customerBody))
+	})
+	mux.HandleFunc("/payment_methods", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(paymentMethodsBody))
+	})
+	mux.HandleFunc("/payment_intents", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		gotPaymentMethod = r.PostForm.Get("payment_method")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"pi_123","status":"succeeded"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &gotPaymentMethod
+}
+
+func validStripeChargeInput() StripeChargeInput {
+	return StripeChargeInput{
+		AmountCents: 2500,
+		Currency:    "usd",
+		CustomerID:  "cus_123",
+	}
+}
+
+func TestCreateAndConfirmExplicitPaymentMethodIsHonoured(t *testing.T) {
+	// A non-empty PaymentMethodID must be used unchanged; the customer and
+	// payment methods endpoints must never be consulted.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/customers/", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("customer lookup must not happen when PaymentMethodID is explicit")
+	})
+	mux.HandleFunc("/payment_methods", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("payment methods listing must not happen when PaymentMethodID is explicit")
+	})
+	var gotPaymentMethod string
+	mux.HandleFunc("/payment_intents", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		gotPaymentMethod = r.PostForm.Get("payment_method")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"pi_123","status":"succeeded"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := NewStripeClient("sk_test", srv.URL)
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPaymentMethod != "pm_explicit" {
+		t.Fatalf("expected payment_method pm_explicit, got %q", gotPaymentMethod)
+	}
+}
+
+func TestCreateAndConfirmResolvesDefaultFromInvoiceSettings(t *testing.T) {
+	srv, gotPaymentMethod := newStripeTestServer(t,
+		`{"id":"cus_123","invoice_settings":{"default_payment_method":"pm_default"}}`,
+		`{"data":[]}`,
+	)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	if _, err := c.CreateAndConfirm(context.Background(), validStripeChargeInput()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *gotPaymentMethod != "pm_default" {
+		t.Fatalf("expected payment_method pm_default, got %q", *gotPaymentMethod)
+	}
+}
+
+func TestCreateAndConfirmFallsBackToFirstPaymentMethod(t *testing.T) {
+	srv, gotPaymentMethod := newStripeTestServer(t,
+		`{"id":"cus_123","invoice_settings":{"default_payment_method":null}}`,
+		`{"data":[{"id":"pm_first"},{"id":"pm_second"}]}`,
+	)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	if _, err := c.CreateAndConfirm(context.Background(), validStripeChargeInput()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *gotPaymentMethod != "pm_first" {
+		t.Fatalf("expected payment_method pm_first, got %q", *gotPaymentMethod)
+	}
+}
+
+func TestCreateAndConfirmNoPaymentMethodFails(t *testing.T) {
+	srv, _ := newStripeTestServer(t,
+		`{"id":"cus_123","invoice_settings":{"default_payment_method":null}}`,
+		`{"data":[]}`,
+	)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	_, err := c.CreateAndConfirm(context.Background(), validStripeChargeInput())
+	if !errors.Is(err, ErrNoPaymentMethod) {
+		t.Fatalf("expected ErrNoPaymentMethod, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cus_123") {
+		t.Fatalf("expected error to name the customer, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- `StripeClient.CreateAndConfirm` (`studio/stripe.go`) only set `payment_method` on the PaymentIntent when the caller supplied `PaymentMethodID`. Without one, Stripe rejected the confirm with a 400 ("missing a payment method"), which is exactly what PR #381 in Payload-Galaxy hits, since the migrated route dropped the default-card resolution that used to live in Next.js (`chargeSavedCard`).
- When `PaymentMethodID` is empty, `CreateAndConfirm` now resolves it server-side: `GET /customers/{id}` for `invoice_settings.default_payment_method`, falling back to the first result of `GET /payment_methods?customer={id}&type=card`. An explicit `PaymentMethodID` still overrides and skips both lookups.
- No payment method resolvable -> `ErrNoPaymentMethod`, wrapped with the customer id, instead of a raw Stripe error.

This matches the product design (purchases charge the artist's default card, set separately via `handleSetDefault`; no per-purchase card selector) and the existing principle that the server never trusts client-supplied `amount` — payment method is the same class of input.

## Test plan

- [x] New `studio/stripe_test.go` (httptest-backed): explicit `PaymentMethodID` is honoured and skips both lookups; default resolved from `invoice_settings`; fallback to the first listed payment method; clear `ErrNoPaymentMethod` naming the customer when neither resolves.
- [x] On remote (`10.10.10.1`): `go build ./...` clean.
- [x] `go test $(go list ./... | grep -v -E '^github\.com/flow-hydraulics/flow-wallet-api$|^.../tests(/|$)')` — all green (this is the CI `unit` job's widened package set).
- [x] `go test -run 'Auth|Route|Scope' .` on the root package — green (the check that caught the earlier crash-loop).
- [x] `gofmt -l .` — no output.
- [x] `go vet ./studio/...` — clean.

Closes #85