### PR TITLE
Charge shipping, expand Stripe metadata, and enforce the production tier cap

### DIFF
--- a/artdrop/migrations.go
+++ b/artdrop/migrations.go
@@ -2,6 +2,7 @@ package artdrop
 
 import (
 	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/migrations/m20260807"
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/migrations/m20260820"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -19,6 +20,11 @@ func Migrations() []*gormigrate.Migration {
 			ID:       m20260807.ID,
 			Migrate:  m20260807.Migrate,
 			Rollback: m20260807.Rollback,
+		},
+		{
+			ID:       m20260820.ID,
+			Migrate:  m20260820.Migrate,
+			Rollback: m20260820.Rollback,
 		},
 	}
 }

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -1,6 +1,7 @@
 package artdrop
 
 import (
+	"math"
 	"net/http"
 	"time"
 
@@ -42,9 +43,11 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	// reports studio pricing as disabled (503).
 	var pricingCacheTTL time.Duration
 	var stripeSecretKey string
+	var shippingRateCentsPerUnit int64
 	if deps.Config != nil {
 		pricingCacheTTL = deps.Config.StudioPricingCacheTTL
 		stripeSecretKey = deps.Config.StripeSecretKey
+		shippingRateCentsPerUnit = int64(math.Round(deps.Config.StudioShippingRatePerUnitUSD * 100))
 	}
 	pricingSvc := pricing.NewActiveService(datastoremongo.NewPricingStore(deps.Mongo, deps.Config), pricingCacheTTL)
 	pricingHandler := pricing.NewHandler(pricingSvc)
@@ -64,7 +67,7 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	chargeEngine := pricing.NewChargeEngine(quoteSvc)
 	stripeClient := studio.NewStripeClient(stripeSecretKey, "")
 	quoteStore := datastoremongo.NewQuoteStore(deps.Mongo, deps.Config)
-	studioService := studio.NewChargeService(studio.NewGormStore(deps.DB), quoteStore, chargeEngine, stripeClient)
+	studioService := studio.NewChargeService(studio.NewGormStore(deps.DB), quoteStore, chargeEngine, stripeClient, shippingRateCentsPerUnit)
 	studioHandler := studio.NewHandler(studioService)
 	router.Handle("/stock-requests:create", studioHandler.CreateStockRequest()).Methods(http.MethodPost)
 	router.Handle("/studio/charges", studioHandler.ListCharges()).Methods(http.MethodGet)

--- a/artdrop/studio/charge_service_test.go
+++ b/artdrop/studio/charge_service_test.go
@@ -28,19 +28,21 @@ func (m *mockQuoteReader) GetByID(ctx context.Context, quoteID string) (*datasto
 }
 
 // mockPriceEngine is a scripted PriceEngine for tests. It mirrors the
-// primitive-only studio.PriceEngine signature.
+// primitive-only studio.PriceEngine signature. maxQuantity defaults to "no
+// cap" (0) when left unset, since most tests don't exercise the tier check.
 type mockPriceEngine struct {
 	amountCents   int64
 	pricingHash   string
 	engineVersion string
+	maxQuantity   int
 	err           error
 }
 
-func (m *mockPriceEngine) Quote(ctx context.Context, config map[string]any, runSize int) (int64, string, string, error) {
+func (m *mockPriceEngine) Quote(ctx context.Context, config map[string]any, runSize int) (int64, string, string, int, error) {
 	if m.err != nil {
-		return 0, "", "", m.err
+		return 0, "", "", 0, m.err
 	}
-	return m.amountCents, m.pricingHash, m.engineVersion, nil
+	return m.amountCents, m.pricingHash, m.engineVersion, m.maxQuantity, nil
 }
 
 // mockChargeClient is a scripted ChargeClient for tests. It records the last
@@ -76,9 +78,18 @@ func (m *mockStore) ListProductionChargesByUser(userID string) ([]ProductionChar
 	return nil, nil
 }
 
+// testShippingRateCentsPerUnit mirrors the production default (envDefault
+// "25" on Config.StudioShippingRatePerUnitUSD, in cents).
+const testShippingRateCentsPerUnit = 2500
+
 // newChargeTestService builds a ServiceImpl wired with the given mocks and a
 // fresh in-memory DB.
 func newChargeTestService(t *testing.T, quotes QuoteReader, engine PriceEngine, charge ChargeClient) Service {
+	t.Helper()
+	return newChargeTestServiceWithShippingRate(t, quotes, engine, charge, testShippingRateCentsPerUnit)
+}
+
+func newChargeTestServiceWithShippingRate(t *testing.T, quotes QuoteReader, engine PriceEngine, charge ChargeClient, shippingRateCentsPerUnit int64) Service {
 	t.Helper()
 	dsn := "file:" + strings.ReplaceAll(t.Name(), "/", "_") + "?mode=memory&cache=shared"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
@@ -88,7 +99,7 @@ func newChargeTestService(t *testing.T, quotes QuoteReader, engine PriceEngine, 
 	if err := db.AutoMigrate(&ProductionCharge{}); err != nil {
 		t.Fatal(err)
 	}
-	return NewChargeService(NewGormStore(db), quotes, engine, charge)
+	return NewChargeService(NewGormStore(db), quotes, engine, charge, shippingRateCentsPerUnit)
 }
 
 func validChargeInput() CreateStockRequestChargeInput {
@@ -370,7 +381,7 @@ func TestCreateStockRequestChargeRecordFailureIsNotLeakedAndNotDuplicate(t *test
 	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
 	store := &mockStore{createErr: errors.New("permission denied for table studio_production_charges (SQLSTATE 42501)")}
 
-	svc := NewChargeService(store, quotes, engine, charge)
+	svc := NewChargeService(store, quotes, engine, charge, testShippingRateCentsPerUnit)
 
 	_, err := svc.CreateStockRequestCharge(context.Background(), validChargeInput())
 	if !errors.Is(err, ErrChargeRecordFailed) {
@@ -381,5 +392,145 @@ func TestCreateStockRequestChargeRecordFailureIsNotLeakedAndNotDuplicate(t *test
 	}
 	if errors.Is(err, ErrChargeAlreadyRecorded) {
 		t.Fatalf("a failed write must not be reported as ErrChargeAlreadyRecorded")
+	}
+}
+
+// TestCreateStockRequestChargePickupChargesNoShipping verifies that a pickup
+// order (the default) charges only the production amount: the pre-existing
+// behavior for every caller that doesn't send fulfillmentMethod.
+func TestCreateStockRequestChargePickupChargesNoShipping(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestService(t, quotes, engine, charge)
+
+	in := validChargeInput()
+	in.FulfillmentMethod = FulfillmentPickup
+
+	got, err := svc.CreateStockRequestCharge(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ShippingAmountCents != 0 {
+		t.Fatalf("expected no shipping for pickup, got %d cents", got.ShippingAmountCents)
+	}
+	if got.ProductionAmountCents != 2500 || got.AmountCents != 2500 {
+		t.Fatalf("expected amount 2500 cents with no shipping, got production=%d total=%d", got.ProductionAmountCents, got.AmountCents)
+	}
+	if charge.lastIn.AmountCents != 2500 {
+		t.Fatalf("expected Stripe to be charged 2500 cents, got %d", charge.lastIn.AmountCents)
+	}
+}
+
+// TestCreateStockRequestChargeUnsetFulfillmentDefaultsToPickup verifies that
+// omitting fulfillmentMethod entirely behaves exactly like pickup, so
+// existing callers (Payload-Galaxy PR #381) are unaffected.
+func TestCreateStockRequestChargeUnsetFulfillmentDefaultsToPickup(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestService(t, quotes, engine, charge)
+
+	in := validChargeInput()
+	in.FulfillmentMethod = ""
+
+	got, err := svc.CreateStockRequestCharge(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ShippingAmountCents != 0 || got.AmountCents != 2500 {
+		t.Fatalf("expected unset fulfillment method to default to pickup (no shipping), got shipping=%d total=%d", got.ShippingAmountCents, got.AmountCents)
+	}
+}
+
+// TestCreateStockRequestChargeDeliveryAddsShipping verifies a delivery order
+// adds the flat per-unit shipping rate times the requested quantity, and that
+// Stripe and the audit record both see the combined total split into its two
+// components.
+func TestCreateStockRequestChargeDeliveryAddsShipping(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestServiceWithShippingRate(t, quotes, engine, charge, 2500)
+
+	in := validChargeInput()
+	in.Quantity = 10
+	in.FulfillmentMethod = FulfillmentDelivery
+
+	got, err := svc.CreateStockRequestCharge(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantShipping := int64(2500 * 10)
+	if got.ShippingAmountCents != wantShipping {
+		t.Fatalf("expected shipping %d cents (rate x quantity), got %d", wantShipping, got.ShippingAmountCents)
+	}
+	if got.ProductionAmountCents != 2500 {
+		t.Fatalf("expected production amount unchanged at 2500 cents, got %d", got.ProductionAmountCents)
+	}
+	wantTotal := int64(2500) + wantShipping
+	if got.AmountCents != wantTotal {
+		t.Fatalf("expected total %d cents, got %d", wantTotal, got.AmountCents)
+	}
+	if charge.lastIn.AmountCents != wantTotal {
+		t.Fatalf("expected Stripe to be charged the combined total %d cents, got %d", wantTotal, charge.lastIn.AmountCents)
+	}
+}
+
+// TestCreateStockRequestChargeQuantityAtMaxTierIsAllowed verifies a request
+// for exactly the largest tier the engine computed is accepted.
+func TestCreateStockRequestChargeQuantityAtMaxTierIsAllowed(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500, maxQuantity: 10}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestService(t, quotes, engine, charge)
+
+	in := validChargeInput()
+	in.Quantity = 10
+
+	if _, err := svc.CreateStockRequestCharge(context.Background(), in); err != nil {
+		t.Fatalf("expected quantity at the max tier to be allowed, got %v", err)
+	}
+}
+
+// TestCreateStockRequestChargeQuantityAboveMaxTierIsRejected verifies a
+// request above the largest tier the engine computed is refused before
+// Stripe is ever called, and that the error names the requested quantity and
+// the max.
+func TestCreateStockRequestChargeQuantityAboveMaxTierIsRejected(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500, maxQuantity: 10}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestService(t, quotes, engine, charge)
+
+	in := validChargeInput()
+	in.Quantity = 11
+
+	_, err := svc.CreateStockRequestCharge(context.Background(), in)
+	if !errors.Is(err, ErrQuantityExceedsMaxTier) {
+		t.Fatalf("expected ErrQuantityExceedsMaxTier, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "11") || !strings.Contains(err.Error(), "10") {
+		t.Fatalf("expected error to name the requested quantity and the max, got %q", err.Error())
+	}
+	if charge.lastIn.AmountCents != 0 {
+		t.Fatalf("expected Stripe NOT to be called when the quantity exceeds the max tier, but it was")
+	}
+}
+
+// TestCreateStockRequestChargeZeroMaxQuantityMeansNoCap verifies that an
+// engine reporting maxQuantity 0 (e.g. an empty Volume slice) does not
+// spuriously reject every request.
+func TestCreateStockRequestChargeZeroMaxQuantityMeansNoCap(t *testing.T) {
+	quotes := &mockQuoteReader{quote: &datastoremongo.StudioQuote{ID: "quote-1", UserID: "user-1", Config: validQuoteConfig()}}
+	engine := &mockPriceEngine{amountCents: 2500, maxQuantity: 0}
+	charge := &mockChargeClient{intent: &StripePaymentIntent{ID: "pi_123", Status: "succeeded"}}
+	svc := newChargeTestService(t, quotes, engine, charge)
+
+	in := validChargeInput()
+	in.Quantity = 1000
+
+	if _, err := svc.CreateStockRequestCharge(context.Background(), in); err != nil {
+		t.Fatalf("expected no cap to be applied when maxQuantity is 0, got %v", err)
 	}
 }

--- a/artdrop/studio/deps.go
+++ b/artdrop/studio/deps.go
@@ -14,13 +14,16 @@ type QuoteReader interface {
 
 // PriceEngine recomputes the price for a Studio stock request from the quote's
 // config snapshot and the active pricing rates. It returns the server-computed
-// amount in cents plus the pricing hash and engine version that produced it.
+// amount in cents, the pricing hash and engine version that produced it, and
+// maxQuantity: the largest production tier the engine itself produces for this
+// config (the same authoritative source as the price), so the caller can
+// reject a requested quantity above it.
 //
 // The interface deliberately uses only primitive types so the engine
 // implementation (in the pricing package) can satisfy it structurally without
 // importing this package, keeping the dependency graph acyclic.
 type PriceEngine interface {
-	Quote(ctx context.Context, config map[string]any, runSize int) (amountCents int64, pricingHash string, engineVersion string, err error)
+	Quote(ctx context.Context, config map[string]any, runSize int) (amountCents int64, pricingHash string, engineVersion string, maxQuantity int, err error)
 }
 
 // ChargeClient creates and confirms a Stripe PaymentIntent. It is implemented

--- a/artdrop/studio/handler_func.go
+++ b/artdrop/studio/handler_func.go
@@ -21,6 +21,9 @@ type createStockRequestRequest struct {
 	UserID            string `json:"userId"`
 	QuoteID           string `json:"quoteId"`
 	QuantityRequested int    `json:"quantityRequested"`
+	// FulfillmentMethod is "delivery" or "pickup". It is optional and
+	// defaults to pickup, matching the behavior before this field existed.
+	FulfillmentMethod string `json:"fulfillmentMethod,omitempty"`
 	StripeCustomerID  string `json:"stripeCustomerId"`
 	PaymentMethodID   string `json:"paymentMethodId,omitempty"`
 	Metadata          string `json:"metadata,omitempty"`
@@ -40,13 +43,14 @@ func (h *Handler) CreateStockRequestFunc(rw http.ResponseWriter, r *http.Request
 	}
 
 	charge, err := h.service.CreateStockRequestCharge(r.Context(), CreateStockRequestChargeInput{
-		UserID:           req.UserID,
-		QuoteID:          req.QuoteID,
-		Quantity:         req.QuantityRequested,
-		StripeCustomerID: req.StripeCustomerID,
-		PaymentMethodID:  req.PaymentMethodID,
-		IdempotencyKey:   r.Header.Get("Idempotency-Key"),
-		Metadata:         req.Metadata,
+		UserID:            req.UserID,
+		QuoteID:           req.QuoteID,
+		Quantity:          req.QuantityRequested,
+		FulfillmentMethod: FulfillmentMethod(req.FulfillmentMethod),
+		StripeCustomerID:  req.StripeCustomerID,
+		PaymentMethodID:   req.PaymentMethodID,
+		IdempotencyKey:    r.Header.Get("Idempotency-Key"),
+		Metadata:          req.Metadata,
 	})
 	if err != nil {
 		switch {
@@ -54,6 +58,8 @@ func (h *Handler) CreateStockRequestFunc(rw http.ResponseWriter, r *http.Request
 			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusConflict, Err: err})
 		case stdErrors.Is(err, ErrQuoteNotFound):
 			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusNotFound, Err: err})
+		case stdErrors.Is(err, ErrQuantityExceedsMaxTier):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusBadRequest, Err: err})
 		case stdErrors.Is(err, ErrPricingDisabled), stdErrors.Is(err, ErrStripeDisabled):
 			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusServiceUnavailable, Err: err})
 		case stdErrors.Is(err, ErrChargeRecordFailed):

--- a/artdrop/studio/handler_test.go
+++ b/artdrop/studio/handler_test.go
@@ -101,6 +101,44 @@ func TestCreateStockRequestHappyPath(t *testing.T) {
 	if svc.lastIn.IdempotencyKey != "idem-abc" {
 		t.Fatalf("expected Idempotency-Key idem-abc propagated to service, got %q", svc.lastIn.IdempotencyKey)
 	}
+	// A request that omits fulfillmentMethod must reach the service as empty,
+	// so the service default (pickup) applies — the pre-existing behavior for
+	// every caller that doesn't send this new field.
+	if svc.lastIn.FulfillmentMethod != "" {
+		t.Fatalf("expected empty FulfillmentMethod when omitted from the request, got %q", svc.lastIn.FulfillmentMethod)
+	}
+}
+
+func TestCreateStockRequestPropagatesFulfillmentMethod(t *testing.T) {
+	svc := &mockStudioService{}
+	h := newStudioHandler(svc)
+
+	body := `{"userId":"user-1","quoteId":"quote-1","quantityRequested":10,"stripeCustomerId":"cus_123","fulfillmentMethod":"delivery"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/stock-requests:create", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	h.CreateStockRequest().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if svc.lastIn.FulfillmentMethod != FulfillmentDelivery {
+		t.Fatalf("expected FulfillmentMethod delivery propagated to service, got %q", svc.lastIn.FulfillmentMethod)
+	}
+}
+
+func TestCreateStockRequestQuantityExceedsMaxTierIsBadRequest(t *testing.T) {
+	h := newStudioHandler(&mockStudioService{err: ErrQuantityExceedsMaxTier})
+
+	body := `{"userId":"user-1","quoteId":"quote-1","quantityRequested":9999,"stripeCustomerId":"cus_123"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/stock-requests:create", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	h.CreateStockRequest().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
 }
 
 func TestCreateStockRequestConflictOnDuplicate(t *testing.T) {

--- a/artdrop/studio/migrations/m20260820/migration.go
+++ b/artdrop/studio/migrations/m20260820/migration.go
@@ -1,0 +1,45 @@
+// m20260820 splits studio_production_charges.amount_cents into its
+// production and shipping components, so ops can reconcile each against the
+// pricing engine and the flat shipping rate separately instead of only
+// seeing a single total.
+package m20260820
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const ID = "20260820"
+
+// StudioProductionCharge is the studio_production_charges model as of this
+// migration: the m20260807 shape plus the production/shipping split.
+type StudioProductionCharge struct {
+	ID                    uint      `gorm:"column:id;primary_key;autoIncrement"`
+	UserID                string    `gorm:"column:user_id;index"`
+	QuoteID               string    `gorm:"column:quote_id;index"`
+	AmountCents           int64     `gorm:"column:amount_cents"`
+	ProductionAmountCents int64     `gorm:"column:production_amount_cents"`
+	ShippingAmountCents   int64     `gorm:"column:shipping_amount_cents"`
+	Currency              string    `gorm:"column:currency;size:3;default:usd"`
+	StripePaymentIntent   string    `gorm:"column:stripe_payment_intent_id;uniqueIndex"`
+	PricingHash           string    `gorm:"column:pricing_hash"`
+	EngineVersion         string    `gorm:"column:engine_version"`
+	Metadata              string    `gorm:"column:metadata;type:text"`
+	CreatedAt             time.Time `gorm:"column:created_at"`
+}
+
+func (StudioProductionCharge) TableName() string {
+	return "studio_production_charges"
+}
+
+func Migrate(tx *gorm.DB) error {
+	return tx.AutoMigrate(&StudioProductionCharge{})
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropColumn(&StudioProductionCharge{}, "production_amount_cents"); err != nil {
+		return err
+	}
+	return tx.Migrator().DropColumn(&StudioProductionCharge{}, "shipping_amount_cents")
+}

--- a/artdrop/studio/pricing/charge_engine.go
+++ b/artdrop/studio/pricing/charge_engine.go
@@ -25,28 +25,42 @@ func NewChargeEngine(svc *QuoteService) *ChargeEngine {
 }
 
 // Quote recomputes the price for the given quote config snapshot and run size,
-// returning the server-computed amount in cents plus the pricing hash and
-// engine version that produced it.
-func (e *ChargeEngine) Quote(ctx context.Context, config map[string]any, runSize int) (amountCents int64, pricingHash string, engineVersion string, err error) {
+// returning the server-computed amount in cents, the pricing hash and engine
+// version that produced it, and the largest production tier the engine itself
+// produces for this config (see maxRunSize).
+func (e *ChargeEngine) Quote(ctx context.Context, config map[string]any, runSize int) (amountCents int64, pricingHash string, engineVersion string, maxQuantity int, err error) {
 	if e == nil || e.svc == nil {
-		return 0, "", "", ErrPricingDisabled
+		return 0, "", "", 0, ErrPricingDisabled
 	}
 
 	cfg, err := toEngineConfig(config)
 	if err != nil {
-		return 0, "", "", fmt.Errorf("translate quote config: %w", err)
+		return 0, "", "", 0, fmt.Errorf("translate quote config: %w", err)
 	}
 	cfg.RunSize = runSize
 
 	result, err := e.svc.Quote(ctx, cfg)
 	if err != nil {
-		return 0, "", "", err
+		return 0, "", "", 0, err
 	}
 
 	// RunTotal is the total price for the run size (the requested quantity),
 	// already floored to the minimum order.
 	amountCents = int64(math.Round(result.RunTotal * 100))
-	return amountCents, result.Hash, result.EngineVersion, nil
+	return amountCents, result.Hash, result.EngineVersion, maxRunSize(result.Volume), nil
+}
+
+// maxRunSize returns the largest production tier the engine computed for a
+// config (the "12 beds" batch, or whatever the last entry is): the same
+// batches slice that backs the price, so a quantity cap derived from it comes
+// from the same authoritative source as the price itself. Volume is ordered
+// from smallest to largest tier and does not depend on the requested run
+// size, so this is stable across quotes for the same config.
+func maxRunSize(volume []VolumePrice) int {
+	if len(volume) == 0 {
+		return 0
+	}
+	return volume[len(volume)-1].Units
 }
 
 // ---------------------------------------------------------------------------

--- a/artdrop/studio/pricing/charge_engine.go
+++ b/artdrop/studio/pricing/charge_engine.go
@@ -51,16 +51,21 @@ func (e *ChargeEngine) Quote(ctx context.Context, config map[string]any, runSize
 }
 
 // maxRunSize returns the largest production tier the engine computed for a
-// config (the "12 beds" batch, or whatever the last entry is): the same
-// batches slice that backs the price, so a quantity cap derived from it comes
-// from the same authoritative source as the price itself. Volume is ordered
-// from smallest to largest tier and does not depend on the requested run
-// size, so this is stable across quotes for the same config.
+// config (normally the "12 beds" batch): the same batches slice that backs
+// the price, so a quantity cap derived from it comes from the same
+// authoritative source as the price itself. This is a security check, so it
+// takes the maximum over Units explicitly rather than trusting Volume to stay
+// sorted — Compute happens to build it ascending today, but nothing enforces
+// that, and a silently-wrong cap from a reordered or inserted tier is exactly
+// the failure mode this check exists to prevent.
 func maxRunSize(volume []VolumePrice) int {
-	if len(volume) == 0 {
-		return 0
+	largest := 0
+	for _, v := range volume {
+		if v.Units > largest {
+			largest = v.Units
+		}
 	}
-	return volume[len(volume)-1].Units
+	return largest
 }
 
 // ---------------------------------------------------------------------------

--- a/artdrop/studio/pricing/charge_engine_test.go
+++ b/artdrop/studio/pricing/charge_engine_test.go
@@ -231,3 +231,26 @@ func TestToEngineConfigNil(t *testing.T) {
 		t.Fatal("expected error for nil config, got nil")
 	}
 }
+
+// TestMaxRunSize verifies the quantity cap is read from the last (largest)
+// entry of the batches Compute produces, the same authoritative source that
+// backs the price, and not an independently maintained maximum.
+func TestMaxRunSize(t *testing.T) {
+	volume := []VolumePrice{
+		{Label: "1 print", Units: 1},
+		{Label: "1 row", Units: 4},
+		{Label: "Full bed", Units: 8},
+		{Label: "12 beds", Units: 96},
+	}
+	if got := maxRunSize(volume); got != 96 {
+		t.Errorf("expected max run size 96, got %d", got)
+	}
+}
+
+// TestMaxRunSizeEmpty verifies an empty batches slice reports no cap (0)
+// rather than panicking.
+func TestMaxRunSizeEmpty(t *testing.T) {
+	if got := maxRunSize(nil); got != 0 {
+		t.Errorf("expected 0 for an empty batches slice, got %d", got)
+	}
+}

--- a/artdrop/studio/pricing/charge_engine_test.go
+++ b/artdrop/studio/pricing/charge_engine_test.go
@@ -232,9 +232,9 @@ func TestToEngineConfigNil(t *testing.T) {
 	}
 }
 
-// TestMaxRunSize verifies the quantity cap is read from the last (largest)
-// entry of the batches Compute produces, the same authoritative source that
-// backs the price, and not an independently maintained maximum.
+// TestMaxRunSize verifies the quantity cap is the maximum Units across the
+// batches Compute produces, the same authoritative source that backs the
+// price, and not an independently maintained maximum.
 func TestMaxRunSize(t *testing.T) {
 	volume := []VolumePrice{
 		{Label: "1 print", Units: 1},
@@ -244,6 +244,22 @@ func TestMaxRunSize(t *testing.T) {
 	}
 	if got := maxRunSize(volume); got != 96 {
 		t.Errorf("expected max run size 96, got %d", got)
+	}
+}
+
+// TestMaxRunSizeDoesNotDependOnOrdering pins that the cap is computed as a
+// true maximum, not by reading the last element: Volume happens to be built
+// ascending today, but this is a security check, so it must not silently go
+// wrong if a future change reorders batches or inserts a tier out of order.
+func TestMaxRunSizeDoesNotDependOnOrdering(t *testing.T) {
+	volume := []VolumePrice{
+		{Label: "Full bed", Units: 8},
+		{Label: "12 beds", Units: 96},
+		{Label: "1 print", Units: 1},
+		{Label: "1 row", Units: 4},
+	}
+	if got := maxRunSize(volume); got != 96 {
+		t.Errorf("expected max run size 96 regardless of slice order, got %d", got)
 	}
 }
 

--- a/artdrop/studio/service.go
+++ b/artdrop/studio/service.go
@@ -32,6 +32,11 @@ var ErrStripeDisabled = errors.New("stripe is disabled")
 // map it to a 5xx so the idempotency middleware releases the key reservation.
 var ErrChargeRecordFailed = errors.New("failed to record charge")
 
+// ErrQuantityExceedsMaxTier is returned when the requested quantity is above
+// the largest production tier the pricing engine computes for the quote's
+// config.
+var ErrQuantityExceedsMaxTier = errors.New("requested quantity exceeds maximum production tier")
+
 // Service lists all functionality provided by the studio service.
 type Service interface {
 	// RecordProductionCharge persists a charge audit record. It is
@@ -49,10 +54,11 @@ type Service interface {
 
 // ServiceImpl implements the studio Service.
 type ServiceImpl struct {
-	store  Store
-	quotes QuoteReader
-	engine PriceEngine
-	charge ChargeClient
+	store                    Store
+	quotes                   QuoteReader
+	engine                   PriceEngine
+	charge                   ChargeClient
+	shippingRateCentsPerUnit int64
 }
 
 // NewService initiates a new studio service.
@@ -62,9 +68,11 @@ func NewService(store Store) Service {
 
 // NewChargeService initiates a studio service wired for the full charge flow
 // (quote reader + pricing engine + Stripe client). Any of the optional deps may
-// be nil; the corresponding step reports its disabled error.
-func NewChargeService(store Store, quotes QuoteReader, engine PriceEngine, charge ChargeClient) Service {
-	return &ServiceImpl{store: store, quotes: quotes, engine: engine, charge: charge}
+// be nil; the corresponding step reports its disabled error. shippingRateCentsPerUnit
+// is the flat per-unit shipping charge applied to delivery orders (see
+// Config.StudioShippingRatePerUnitUSD).
+func NewChargeService(store Store, quotes QuoteReader, engine PriceEngine, charge ChargeClient, shippingRateCentsPerUnit int64) Service {
+	return &ServiceImpl{store: store, quotes: quotes, engine: engine, charge: charge, shippingRateCentsPerUnit: shippingRateCentsPerUnit}
 }
 
 // RecordProductionCharge persists a charge audit record, guarding against
@@ -84,14 +92,16 @@ func (s *ServiceImpl) RecordProductionCharge(in CreateProductionChargeInput) (*P
 	}
 
 	charge := &ProductionCharge{
-		UserID:              in.UserID,
-		QuoteID:             in.QuoteID,
-		AmountCents:         in.AmountCents,
-		Currency:            in.Currency,
-		StripePaymentIntent: in.StripePaymentIntent,
-		PricingHash:         in.PricingHash,
-		EngineVersion:       in.EngineVersion,
-		Metadata:            in.Metadata,
+		UserID:                in.UserID,
+		QuoteID:               in.QuoteID,
+		AmountCents:           in.AmountCents,
+		ProductionAmountCents: in.ProductionAmountCents,
+		ShippingAmountCents:   in.ShippingAmountCents,
+		Currency:              in.Currency,
+		StripePaymentIntent:   in.StripePaymentIntent,
+		PricingHash:           in.PricingHash,
+		EngineVersion:         in.EngineVersion,
+		Metadata:              in.Metadata,
 	}
 
 	if err := s.store.CreateProductionCharge(charge); err != nil {
@@ -129,6 +139,10 @@ func (s *ServiceImpl) CreateStockRequestCharge(ctx context.Context, in CreateSto
 	if in.IdempotencyKey == "" {
 		return nil, fmt.Errorf("idempotency key is required")
 	}
+	fulfillment := in.FulfillmentMethod
+	if fulfillment == "" {
+		fulfillment = FulfillmentPickup
+	}
 
 	// 1. Read the quote's config snapshot from Mongo.
 	if s.quotes == nil {
@@ -149,20 +163,39 @@ func (s *ServiceImpl) CreateStockRequestCharge(ctx context.Context, in CreateSto
 		return nil, ErrQuoteNotFound
 	}
 
-	// 2. Recompute the exact price with the active rates from the quote's
-	// config snapshot and the requested quantity as the run size. The engine
-	// returns the server-computed amount in cents plus the pricing hash and
-	// engine version that produced it.
+	// 2. Recompute the exact production price with the active rates from the
+	// quote's config snapshot and the requested quantity as the run size. The
+	// engine returns the server-computed amount in cents, the pricing hash and
+	// engine version that produced it, and the largest production tier it
+	// computes for this config.
 	if s.engine == nil {
 		return nil, ErrPricingDisabled
 	}
-	amountCents, pricingHash, engineVersion, err := s.engine.Quote(ctx, quote.Config, in.Quantity)
+	productionCents, pricingHash, engineVersion, maxQuantity, err := s.engine.Quote(ctx, quote.Config, in.Quantity)
 	if err != nil {
 		return nil, fmt.Errorf("recompute quote price: %w", err)
 	}
-	if amountCents <= 0 {
-		return nil, fmt.Errorf("computed charge amount must be positive (got %d cents)", amountCents)
+	if productionCents <= 0 {
+		return nil, fmt.Errorf("computed charge amount must be positive (got %d cents)", productionCents)
 	}
+
+	// 3. The requested quantity must not exceed the largest production tier
+	// the engine itself computes for this config — the same authoritative
+	// source as the price, rather than a cached, client-manipulable copy of
+	// it.
+	if maxQuantity > 0 && in.Quantity > maxQuantity {
+		return nil, fmt.Errorf("%w: requested %d, max %d", ErrQuantityExceedsMaxTier, in.Quantity, maxQuantity)
+	}
+
+	// 4. Add shipping for a delivery order. The rate is server-configured;
+	// only whether it applies at all is taken from the client (see
+	// CreateStockRequestChargeInput.FulfillmentMethod for the trust
+	// boundary this implies).
+	var shippingCents int64
+	if fulfillment == FulfillmentDelivery {
+		shippingCents = s.shippingRateCentsPerUnit * int64(in.Quantity)
+	}
+	amountCents := productionCents + shippingCents
 
 	// 5. Create and confirm the Stripe PaymentIntent.
 	if s.charge == nil {
@@ -180,16 +213,19 @@ func (s *ServiceImpl) CreateStockRequestCharge(ctx context.Context, in CreateSto
 		return nil, fmt.Errorf("create stripe payment intent: %w", err)
 	}
 
-	// 6. Persist the audit record with the server-computed values.
+	// 6. Persist the audit record with the server-computed values, split into
+	// production vs shipping so ops can reconcile against each separately.
 	charge, err := s.RecordProductionCharge(CreateProductionChargeInput{
-		UserID:              in.UserID,
-		QuoteID:             in.QuoteID,
-		AmountCents:         amountCents,
-		Currency:            "usd",
-		StripePaymentIntent: intent.ID,
-		PricingHash:         pricingHash,
-		EngineVersion:       engineVersion,
-		Metadata:            in.Metadata,
+		UserID:                in.UserID,
+		QuoteID:               in.QuoteID,
+		AmountCents:           amountCents,
+		ProductionAmountCents: productionCents,
+		ShippingAmountCents:   shippingCents,
+		Currency:              "usd",
+		StripePaymentIntent:   intent.ID,
+		PricingHash:           pricingHash,
+		EngineVersion:         engineVersion,
+		Metadata:              in.Metadata,
 	})
 	if err != nil {
 		return nil, err

--- a/artdrop/studio/stripe.go
+++ b/artdrop/studio/stripe.go
@@ -8,8 +8,19 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
+)
+
+// Stripe's metadata limits: at most this many keys per object, and this many
+// characters per value. A charge whose caller-supplied metadata exceeds
+// either is truncated/dropped deterministically rather than rejected whole by
+// Stripe. Stripe also caps key length at 40 characters.
+const (
+	stripeMetadataMaxKeys       = 50
+	stripeMetadataMaxKeyChars   = 40
+	stripeMetadataMaxValueChars = 500
 )
 
 // ErrNoPaymentMethod is returned when a customer has no saved payment method
@@ -73,7 +84,11 @@ func (c *StripeClient) CreateAndConfirm(ctx context.Context, in StripeChargeInpu
 	form.Set("off_session", "true")
 	form.Set("payment_method", paymentMethodID)
 	form.Set("automatic_payment_methods[enabled]", "true")
-	if in.Metadata != "" {
+	if fields := stripeMetadataFields(in.Metadata); fields != nil {
+		for k, v := range fields {
+			form.Set("metadata["+k+"]", v)
+		}
+	} else if in.Metadata != "" {
 		form.Set("metadata[charge_ref]", in.Metadata)
 	}
 
@@ -173,6 +188,65 @@ func (c *StripeClient) do(req *http.Request, out any) error {
 		}
 	}
 	return nil
+}
+
+// stripeMetadataFields parses raw as a JSON object and returns it as a flat
+// string-to-string map suitable for one metadata[<key>]=<value> form field
+// per entry, so ops can filter Stripe charges by editionId/artistProfileId/
+// type in the dashboard instead of only by an opaque charge_ref. It returns
+// nil when raw is empty or is not a JSON object, so the caller can fall back
+// to the single charge_ref field.
+//
+// Stripe's key/value limits are enforced deterministically: keys are sorted
+// so which ones survive is stable across calls with the same input, only the
+// first stripeMetadataMaxKeys are kept, and each key/value is truncated to
+// Stripe's character limits rather than left for Stripe to reject the whole
+// request over.
+func stripeMetadataFields(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		return nil
+	}
+
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > stripeMetadataMaxKeys {
+		keys = keys[:stripeMetadataMaxKeys]
+	}
+
+	fields := make(map[string]string, len(keys))
+	for _, k := range keys {
+		key := truncate(k, stripeMetadataMaxKeyChars)
+		fields[key] = truncate(stripeMetadataValueString(obj[k]), stripeMetadataMaxValueChars)
+	}
+	return fields
+}
+
+// stripeMetadataValueString renders a decoded JSON value as the string Stripe
+// metadata needs: strings pass through unchanged, everything else (numbers,
+// bools, nested objects/arrays, null) is re-encoded as JSON text.
+func stripeMetadataValueString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
 }
 
 // StripeChargeInput is the data needed to create and confirm a PaymentIntent.

--- a/artdrop/studio/stripe_test.go
+++ b/artdrop/studio/stripe_test.go
@@ -2,9 +2,12 @@ package studio
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -123,5 +126,143 @@ func TestCreateAndConfirmNoPaymentMethodFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cus_123") {
 		t.Fatalf("expected error to name the customer, got %q", err.Error())
+	}
+}
+
+// newMetadataCaptureServer wires a mux that only answers /payment_intents and
+// records the full posted form, so tests can inspect every metadata[...]
+// field the request carried. Tests using it must supply an explicit
+// PaymentMethodID so CreateAndConfirm never needs the customer/payment
+// methods endpoints (unregistered here).
+func newMetadataCaptureServer(t *testing.T) (*httptest.Server, *url.Values) {
+	t.Helper()
+	var got url.Values
+	mux := http.NewServeMux()
+	mux.HandleFunc("/payment_intents", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"pi_123","status":"succeeded"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &got
+}
+
+func TestCreateAndConfirmExpandsJSONMetadataIntoSeparateKeys(t *testing.T) {
+	srv, gotForm := newMetadataCaptureServer(t)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+	in.Metadata = `{"editionId":"ed_1","artistProfileId":"ap_1","type":"production"}`
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for key, want := range map[string]string{"editionId": "ed_1", "artistProfileId": "ap_1", "type": "production"} {
+		if got := gotForm.Get("metadata[" + key + "]"); got != want {
+			t.Errorf("expected metadata[%s]=%q, got %q", key, want, got)
+		}
+	}
+	if gotForm.Get("metadata[charge_ref]") != "" {
+		t.Errorf("expected no fallback charge_ref field when metadata expands, got %q", gotForm.Get("metadata[charge_ref]"))
+	}
+}
+
+func TestCreateAndConfirmFallsBackToChargeRefOnNonJSONMetadata(t *testing.T) {
+	srv, gotForm := newMetadataCaptureServer(t)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+	in.Metadata = "not-json-just-a-ref-123"
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := gotForm.Get("metadata[charge_ref]"); got != in.Metadata {
+		t.Errorf("expected metadata[charge_ref]=%q, got %q", in.Metadata, got)
+	}
+}
+
+func TestCreateAndConfirmFallsBackToChargeRefOnJSONArrayMetadata(t *testing.T) {
+	// A JSON array is valid JSON but not an object: it must fall back rather
+	// than being treated as expandable key/value metadata.
+	srv, gotForm := newMetadataCaptureServer(t)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+	in.Metadata = `["ed_1","ap_1"]`
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := gotForm.Get("metadata[charge_ref]"); got != in.Metadata {
+		t.Errorf("expected metadata[charge_ref]=%q, got %q", in.Metadata, got)
+	}
+}
+
+func TestCreateAndConfirmMetadataTruncatesLongValue(t *testing.T) {
+	srv, gotForm := newMetadataCaptureServer(t)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	longValue := strings.Repeat("x", 600)
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+	in.Metadata = fmt.Sprintf(`{"note":%q}`, longValue)
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := gotForm.Get("metadata[note]")
+	if len(got) != stripeMetadataMaxValueChars {
+		t.Fatalf("expected value truncated to %d chars, got %d", stripeMetadataMaxValueChars, len(got))
+	}
+	if got != longValue[:stripeMetadataMaxValueChars] {
+		t.Fatalf("expected truncated value to be a prefix of the original")
+	}
+}
+
+func TestCreateAndConfirmMetadataDropsKeysBeyondLimit(t *testing.T) {
+	srv, gotForm := newMetadataCaptureServer(t)
+	c := NewStripeClient("sk_test", srv.URL)
+
+	obj := make(map[string]string, stripeMetadataMaxKeys+5)
+	for i := 0; i < stripeMetadataMaxKeys+5; i++ {
+		obj[fmt.Sprintf("key%03d", i)] = "v"
+	}
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := validStripeChargeInput()
+	in.PaymentMethodID = "pm_explicit"
+	in.Metadata = string(raw)
+
+	if _, err := c.CreateAndConfirm(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	count := 0
+	for key := range *gotForm {
+		if strings.HasPrefix(key, "metadata[key") {
+			count++
+		}
+	}
+	if count != stripeMetadataMaxKeys {
+		t.Fatalf("expected exactly %d metadata keys kept, got %d", stripeMetadataMaxKeys, count)
+	}
+	// The rule is deterministic: the lexicographically first N keys survive.
+	if gotForm.Get("metadata[key000]") != "v" {
+		t.Errorf("expected key000 (sorted first) to survive truncation")
+	}
+	if gotForm.Get(fmt.Sprintf("metadata[key%03d]", stripeMetadataMaxKeys+4)) != "" {
+		t.Errorf("expected the lexicographically last key to be dropped")
 	}
 }

--- a/artdrop/studio/studio.go
+++ b/artdrop/studio/studio.go
@@ -9,18 +9,35 @@ package studio
 
 import "time"
 
+// FulfillmentMethod is how a Studio stock request's prints reach the artist:
+// picked up at the studio (no shipping charge) or delivered (a flat
+// per-unit shipping charge is added). It is client-supplied metadata about
+// the order, not a trusted amount: the server always computes the shipping
+// total itself from the method and the requested quantity.
+type FulfillmentMethod string
+
+const (
+	FulfillmentPickup   FulfillmentMethod = "pickup"
+	FulfillmentDelivery FulfillmentMethod = "delivery"
+)
+
 // ProductionCharge is the audit record for a single Studio production charge.
+// AmountCents is the total actually charged; ProductionAmountCents and
+// ShippingAmountCents split it into the two components ops reconciles
+// against. ShippingAmountCents is 0 for a pickup order.
 type ProductionCharge struct {
-	ID                  uint      `json:"id" gorm:"column:id;primary_key;autoIncrement"`
-	UserID              string    `json:"userId" gorm:"column:user_id;index"`
-	QuoteID             string    `json:"quoteId" gorm:"column:quote_id;index"`
-	AmountCents         int64     `json:"amountCents" gorm:"column:amount_cents"`
-	Currency            string    `json:"currency" gorm:"column:currency;size:3;default:usd"`
-	StripePaymentIntent string    `json:"stripePaymentIntentId" gorm:"column:stripe_payment_intent_id;uniqueIndex"`
-	PricingHash         string    `json:"pricingHash" gorm:"column:pricing_hash"`
-	EngineVersion       string    `json:"engineVersion" gorm:"column:engine_version"`
-	Metadata            string    `json:"metadata" gorm:"column:metadata;type:text"`
-	CreatedAt           time.Time `json:"createdAt" gorm:"column:created_at"`
+	ID                    uint      `json:"id" gorm:"column:id;primary_key;autoIncrement"`
+	UserID                string    `json:"userId" gorm:"column:user_id;index"`
+	QuoteID               string    `json:"quoteId" gorm:"column:quote_id;index"`
+	AmountCents           int64     `json:"amountCents" gorm:"column:amount_cents"`
+	ProductionAmountCents int64     `json:"productionAmountCents" gorm:"column:production_amount_cents"`
+	ShippingAmountCents   int64     `json:"shippingAmountCents" gorm:"column:shipping_amount_cents"`
+	Currency              string    `json:"currency" gorm:"column:currency;size:3;default:usd"`
+	StripePaymentIntent   string    `json:"stripePaymentIntentId" gorm:"column:stripe_payment_intent_id;uniqueIndex"`
+	PricingHash           string    `json:"pricingHash" gorm:"column:pricing_hash"`
+	EngineVersion         string    `json:"engineVersion" gorm:"column:engine_version"`
+	Metadata              string    `json:"metadata" gorm:"column:metadata;type:text"`
+	CreatedAt             time.Time `json:"createdAt" gorm:"column:created_at"`
 }
 
 // TableName returns the table name for the audit record.
@@ -31,15 +48,18 @@ func (ProductionCharge) TableName() string {
 // CreateProductionChargeInput is the data needed to record a charge. The
 // PricingHash is a fingerprint of the config/rate/engine version used to
 // compute the amount at charge time (produced by the pricing engine, #70).
+// AmountCents must equal ProductionAmountCents + ShippingAmountCents.
 type CreateProductionChargeInput struct {
-	UserID              string
-	QuoteID             string
-	AmountCents         int64
-	Currency            string
-	StripePaymentIntent string
-	PricingHash         string
-	EngineVersion       string
-	Metadata            string
+	UserID                string
+	QuoteID               string
+	AmountCents           int64
+	ProductionAmountCents int64
+	ShippingAmountCents   int64
+	Currency              string
+	StripePaymentIntent   string
+	PricingHash           string
+	EngineVersion         string
+	Metadata              string
 }
 
 // CreateStockRequestChargeInput is the data needed to charge a Studio stock
@@ -48,16 +68,25 @@ type CreateProductionChargeInput struct {
 // identifies the user, the quote and the quantity, plus the Stripe payment
 // details. No amount, hash or engine version is trusted from the client.
 //
+// FulfillmentMethod controls whether a shipping charge is added; the rate
+// itself is server-configured (see Config.StudioShippingRatePerUnitUSD), so
+// only whether shipping applies is client-supplied. A caller could
+// understate shipping by claiming pickup when the order is actually
+// delivered — that trust boundary is weaker than the amount, which is
+// entirely server-computed. It defaults to pickup so existing callers that
+// don't send it keep paying nothing extra, matching today's behavior.
+//
 // IdempotencyKey is the client-supplied Idempotency-Key header. It is
 // propagated to Stripe so that an HTTP replay of the same logical purchase
 // maps to the same PaymentIntent, while a genuinely new purchase (a new key)
 // is allowed to charge again.
 type CreateStockRequestChargeInput struct {
-	UserID           string
-	QuoteID          string
-	Quantity         int
-	StripeCustomerID string
-	PaymentMethodID  string
-	IdempotencyKey   string
-	Metadata         string
+	UserID            string
+	QuoteID           string
+	Quantity          int
+	FulfillmentMethod FulfillmentMethod
+	StripeCustomerID  string
+	PaymentMethodID   string
+	IdempotencyKey    string
+	Metadata          string
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -207,6 +207,11 @@ type Config struct {
 	// for Studio production charges. When empty, the Stripe client is not
 	// initialized and the charge endpoint reports the feature as disabled.
 	StripeSecretKey string `env:"STRIPE_SECRET_KEY" envDefault:""`
+	// StudioShippingRatePerUnitUSD is the flat shipping rate, in whole USD,
+	// charged per unit on a delivery stock request. It is applied server-side
+	// in stock-requests:create; a config value rather than a literal so ops
+	// can change it without a code deploy.
+	StudioShippingRatePerUnitUSD float64 `env:"STUDIO_SHIPPING_RATE_PER_UNIT_USD" envDefault:"25"`
 }
 
 // Parse parses environment variables and flags to a valid Config.

--- a/openapi.yml
+++ b/openapi.yml
@@ -1544,9 +1544,13 @@ paths:
         recomputes the exact price with the active pricing rates, creates and
         confirms a Stripe PaymentIntent, and persists the audit record with the
         server-computed amount, hash and engine version. No amount, hash or
-        engine version is trusted from the client. Retries are governed by the
-        `Idempotency-Key` header, which is propagated to Stripe; replays return
-        the stored result, while a conflicting duplicate attempt returns 409.
+        engine version is trusted from the client. A delivery order adds a
+        flat, server-configured per-unit shipping charge on top of the
+        recomputed production price; `quantityRequested` is rejected if it
+        exceeds the largest production tier the pricing engine computes for
+        the quote's config. Retries are governed by the `Idempotency-Key`
+        header, which is propagated to Stripe; replays return the stored
+        result, while a conflicting duplicate attempt returns 409.
       operationId: createStockRequest
       x-required-scopes:
         - studio.charge.create
@@ -1570,6 +1574,14 @@ paths:
                 quantityRequested:
                   type: integer
                   minimum: 1
+                fulfillmentMethod:
+                  type: string
+                  enum: [pickup, delivery]
+                  default: pickup
+                  description: >-
+                    Whether the order is picked up (no shipping charge) or
+                    delivered (a flat, server-configured per-unit shipping
+                    charge is added). Defaults to pickup when omitted.
                 stripeCustomerId:
                   type: string
                 paymentMethodId:
@@ -1584,7 +1596,7 @@ paths:
               schema:
                 type: object
         '400':
-          description: Bad Request
+          description: Bad Request - malformed body or quantityRequested exceeds the maximum production tier
         '404':
           description: Not Found - studio quote does not exist or does not belong to the user
         '409':


### PR DESCRIPTION
Closes #89.

Three gaps in `POST /v1/stock-requests:create`, all fixable server-side. PR #381 in Payload-Galaxy already proxies this endpoint in production, so every new field is optional and defaults to today's behavior.

## 1. Shipping

Adds an optional `fulfillmentMethod` field (`"delivery"` / `"pickup"`, defaulting to `"pickup"`). For a delivery order, the server adds a flat per-unit shipping charge on top of the recomputed production price. The rate is `Config.StudioShippingRatePerUnitUSD` (`STUDIO_SHIPPING_RATE_PER_UNIT_USD`, `envDefault:"25"`), not a literal, so ops can change it without a deploy.

The audit record (`ProductionCharge`) now has `productionAmountCents` and `shippingAmountCents` alongside the existing `amountCents` total, via migration `m20260820` (additive, follows the `m20211220` "AutoMigrate a widened struct" pattern already used in this repo).

**Trust boundary:** `fulfillmentMethod` is client-supplied — a caller could understate shipping by claiming pickup on an order that's actually delivered. I didn't find a way to derive it server-side (nothing in the quote's config snapshot encodes it); the amount itself stays fully server-computed either way, so the exposure is limited to the flat shipping fee, not the production price.

**Coordination note for the frontend team:** defaulting `fulfillmentMethod` to pickup is what keeps existing callers working — but it also means a delivery order that doesn't send the field is charged **no shipping at all**. Today that's safe because Payload-Galaxy refuses deliveries with a 501 behind a feature flag, so nothing is undercharged yet. Whoever removes that 501 must start sending `fulfillmentMethod: "delivery"` in the *same* change, not after — otherwise the failure mode is an artist getting free shipping, discovered by ops rather than by review.

## 2. Stripe metadata

`CreateAndConfirm` parses the caller's `metadata` string as a JSON object and sets each key as its own `metadata[<key>]` Stripe field (so ops can filter by `editionId`/`artistProfileId`/`type` in the dashboard again). Keys are sorted and capped at 50, keys/values are truncated to Stripe's 40/500-char limits — a deterministic rule so an oversized payload degrades instead of getting the whole charge rejected by Stripe. A non-JSON-object string (including a JSON array) falls back to today's single `metadata[charge_ref]` field unchanged.

## 3. Production tier cap

`quantityRequested` is now rejected (400, naming the requested quantity and the max) when it exceeds the largest production tier the pricing engine itself computes for the quote's config — the same `batches` slice (`pricing.go`) that backs the recomputed price — instead of trusting the client or the cached, Mongo-manipulable `productionEstimate.tiers` copy of it. `PriceEngine.Quote` gained a `maxQuantity` return value; `ChargeEngine.Quote` derives it from `Result.Volume` via `maxRunSize`, which takes `max(Units)` explicitly rather than reading the last entry — this is a security check, so it doesn't depend on `Volume` staying sorted, even though it happens to be built ascending today. Pinned with a test using a deliberately out-of-order slice.

## CI gate (remote, per Rule Zero)

- `go build ./...` — clean
- `go test ./artdrop/... ./configs/... ./plugins/...` — all pass, including new tests for pickup/delivery shipping, metadata expansion/truncation/fallback, the tier cap (at-max allowed, above-max rejected), and `maxRunSize` order-independence
- `go test -run 'Auth|Route|Scope' .` on the root package — pass
- `gofmt -l .` — clean
- `./tests/...` not run — pre-existing emulator-dependent failures unrelated to this change, per team instructions