### PR TITLE
Exempt health check endpoints from auth

### DIFF
--- a/handlers/middleware/auth.go
+++ b/handlers/middleware/auth.go
@@ -47,6 +47,23 @@ func ContextWithClaims(ctx context.Context, claims *AuthClaims) context.Context 
 	return context.WithValue(ctx, claimsContextKey{}, claims)
 }
 
+// healthCheckExemptPaths lets Kubernetes readiness/liveness probes reach the
+// health endpoints without a bearer token: probes never send one, and with
+// auth enabled a 401 here means the pod never becomes ready and the rollout
+// stalls forever. Deliberately a compile-time allowlist matched on exact
+// method+path, not a prefix or an env-configurable list: a prefix on
+// /v1/health would silently exempt any future /v1/health/* route, and an
+// env-configurable list is a silent security hole waiting for a typo.
+var healthCheckExemptPaths = map[string]struct{}{
+	http.MethodGet + " /v1/health/ready":    {},
+	http.MethodGet + " /v1/health/liveness": {},
+}
+
+func isHealthCheckExempt(method, path string) bool {
+	_, ok := healthCheckExemptPaths[method+" "+path]
+	return ok
+}
+
 var pathParamPattern = regexp.MustCompile(`\\\{[^}]+\\\}`)
 
 func NewAuthRule(method string, pathTemplate string, requiredScope string) AuthRule {
@@ -68,6 +85,11 @@ func AuthHandler(h http.Handler, opts AuthOptions) http.Handler {
 	}
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if isHealthCheckExempt(r.Method, r.URL.Path) {
+			h.ServeHTTP(rw, r)
+			return
+		}
+
 		requiredScope, ok := requiredScopeForRequest(opts.Rules, r.Method, r.URL.Path)
 		if !ok {
 			log.WithFields(log.Fields{"method": r.Method, "path": r.URL.Path}).Warn("auth denied: endpoint scope missing")

--- a/handlers/middleware/auth_test.go
+++ b/handlers/middleware/auth_test.go
@@ -65,6 +65,55 @@ func TestAuthHandler(t *testing.T) {
 	})
 }
 
+func TestAuthHandlerHealthCheckExemption(t *testing.T) {
+	secret := "test-secret"
+	rules := []AuthRule{
+		{
+			Method:        http.MethodGet,
+			PathPattern:   regexp.MustCompile(`^/v1/health/ready$`),
+			RequiredScope: "health.read",
+		},
+		{
+			Method:        http.MethodGet,
+			PathPattern:   regexp.MustCompile(`^/v1/accounts$`),
+			RequiredScope: "account.read",
+		},
+	}
+
+	h := AuthHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}), AuthOptions{Enabled: true, Secret: secret, Rules: rules})
+
+	t.Run("health endpoint returns 200 without a token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/health/ready", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+
+	t.Run("health endpoint returns 200 with a valid token too", func(t *testing.T) {
+		tok := signedToken(t, secret, "health.read", time.Now().Add(5*time.Minute))
+		req := httptest.NewRequest(http.MethodGet, "/v1/health/ready", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, rr.Code)
+		}
+	})
+
+	t.Run("non-health endpoint still returns 401 without a token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/accounts", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+		}
+	})
+}
+
 func signedToken(t *testing.T, secret string, scope string, exp time.Time) string {
 	t.Helper()
 	claims := AuthClaims{


### PR DESCRIPTION
Closes #91.

Enabling auth hung the testnet deploy forever: the readiness probe (GET /v1/health/ready, no Authorization header) got 401'd by the auth middleware, so the pod never became ready and the rollout stalled indefinitely.

`AuthHandler` now exempts exactly `GET /v1/health/ready` and `GET /v1/health/liveness` before the scope lookup, via a compile-time map in `handlers/middleware/auth.go`. openapi.yml still declares `health.read` for both routes (`AuthRulesFromRouter` fails startup on any route without a declared scope), so the auth rules are still built for them — the exemption just runs before those rules are consulted, and skips token validation entirely.

Matched on exact method+path, not a prefix on `/v1/health`. A prefix would silently exempt any future `/v1/health/*` route without a second thought; an exact allowlist forces that to be a deliberate decision instead. Not configurable by env, so a bad config can't quietly widen it.

## Test plan
- [x] `go test ./handlers/middleware/...` — new `TestAuthHandlerHealthCheckExemption`: health endpoints return 200 without a token and with a valid token, a non-health endpoint still returns 401 without one.
- [x] `go test -run 'Auth|Route|Scope' .` on the root package — green.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- [x] `./tests/...` failures reproduce identically on `main` (emulator not running locally) — unrelated to this change.