### PR TITLE
93: Add buyer purchase charge + escrow endpoint with server-computed amount

### DIFF
--- a/artdrop/escrow_amount_validation_test.go
+++ b/artdrop/escrow_amount_validation_test.go
@@ -9,132 +9,70 @@ import (
 	"github.com/onflow/flow-go-sdk"
 )
 
-// This file documents and pins the escrow `amount` validation gap first
-// reported live against a real Flow emulator on 2026-08-06 (see
-// flow-accounts-manager/INFORME_ESCROW_LIVE_TEST.md, sections 8-9),
-// re-verified by static reading on 2026-08-18, and re-verified again on
-// 2026-08-19 against the config-driven-addresses branch and the
-// escrow-lifecycle redesign (new EscrowModule, cancel/refund deleted).
+// This file documents the escrow `amount` validation gap first reported live
+// against a real Flow emulator on 2026-08-06 (see
+// flow-accounts-manager/INFORME_ESCROW_LIVE_TEST.md, sections 8-9), re-verified
+// by static reading on 2026-08-18, and re-verified again on 2026-08-19 against
+// the config-driven-addresses branch and the escrow-lifecycle redesign (new
+// EscrowModule, cancel/refund deleted).
 //
-// Confirmed facts this test encodes, current as of the redesign:
+// Confirmed facts this file encodes, current as of the redesign:
 //
 //  1. CreateEscrow (artdrop/service.go) ALWAYS uses Config.AdminAddress as
-//     the transaction proposer (and, per transactions/service.go, the
-//     admin is also always the fee payer). The `address` path parameter is
-//     validated but never used as proposer. The `amount` field is parsed
-//     with newUFix64 and forwarded verbatim as a UFix64 argument with no
-//     comparison against a sale price, a percentage, a balance, or any cap.
-//     Still true today — nothing in the config-driven-addresses work or the
-//     escrow redesign touched amount validation.
+//     the transaction proposer (and, per transactions/service.go, the admin is
+//     also always the fee payer). The `address` path parameter is validated but
+//     never used as proposer. The `amount` field is parsed with newUFix64 and
+//     forwarded verbatim as a UFix64 argument with no comparison against a sale
+//     price, a percentage, a balance, or any cap.
 //
-//  2. create_escrow.cdc withdraws `amount` from the SIGNER's own vault, and
-//     the signer is always the admin (see 1) — so the vault actually
-//     debited is the admin wallet's, not the buyer's, regardless of what
-//     `buyer`/`address` say. VaultIdentifier used to be a client-supplied
-//     storage path on that same admin account; it's now fixed server-side
-//     to "flowTokenVault" (defaultVaultIdentifier), which narrows *which*
-//     admin vault gets hit but doesn't touch the underlying gap — `amount`
-//     is still forwarded unchecked, still debited from the admin's own
-//     FLOW vault.
+//  2. create_escrow.cdc withdraws `amount` from the SIGNER's own vault, and the
+//     signer is always the admin (see 1) — so the vault actually debited is the
+//     admin wallet's, not the buyer's. VaultIdentifier is fixed server-side to
+//     "flowTokenVault" (defaultVaultIdentifier).
 //
 //  3. SEVERITY SHIFT (2026-08-19, escrow-lifecycle redesign): the original
-//     audit chained #1/#2 into a theft: create an escrow naming yourself
-//     buyer with an inflated `amount`, then Cancel (pre-unlock) or Refund
-//     (post-unlock) to route the admin-debited funds back to a vault you
-//     control — see the former TestEscrowCreateThenCancel_
-//     RoundTripsToSelfDeclaredBuyerWithoutSalePriceCheck, deleted below.
-//     `cancel` and `refund` no longer exist anywhere in EscrowModule or in
-//     this API (see the artdrop-cdc-audit commits on this branch) — that
-//     return path is gone, not just gated differently. activateChipAndSettle
-//     never pays a customer either; released FLOW always lands in ArtDrop's
-//     own vault. So an unvalidated `amount` can no longer be routed back to
-//     an attacker — the money isn't stolen, it's stuck: it locks up
-//     ArtDrop's own FLOW in an escrow that only comes back via the
-//     OperationalAdmin-gated timeout release (which, separately, nothing in
-//     this wallet API currently has a path to trigger — see the
-//     escrow-lifecycle-redesign audit report). That makes this an
-//     availability/accounting problem, not a theft — still worth fixing,
-//     no longer urgent.
-
-// TestCreateEscrow_RejectsAmountUnrelatedToAnySalePrice encodes the DESIRED
-// behavior: the server must not accept an `amount` it cannot justify against
-// a real sale. No `sale_price` field exists anywhere in CreateEscrowRequest
-// today (that absence is itself part of the bug — see the audit report), so
-// this test uses a conservative placeholder ceiling instead of a real
-// percentage check. Whatever shape the eventual fix takes (sale_price field
-// + 5% comparison, admin-configured cap, balance check, ...), it must cause
-// this request to be rejected.
+//     audit chained #1/#2 into a theft via Cancel/Refund routing admin-debited
+//     funds back to a caller-controlled vault. `cancel` and `refund` no longer
+//     exist anywhere in EscrowModule or in this API — that return path is gone.
+//     activateChipAndSettle never pays a customer either; released FLOW always
+//     lands in ArtDrop's own vault. So an unvalidated `amount` can no longer be
+//     routed back to an attacker — the money isn't stolen, it's stuck. That
+//     makes this an availability/accounting problem, not a theft.
 //
-// This test documents a real gap but is SKIPPED rather than left red: a
-// deliberately-failing test in a package CI is about to start running
-// (./artdrop/... is on the list for the planned handlers/configs -> +artdrop
-// +studio +datastore/mongo CI expansion) would turn that expansion red on
-// day one, and the likely outcome is someone excludes the package again —
-// which would hide the real, currently-uncovered bugs that expansion exists
-// to catch (a broken quote lookup already shipped once because of that
-// coverage gap). Un-skip this the moment amount validation lands.
-func TestCreateEscrow_RejectsAmountUnrelatedToAnySalePrice(t *testing.T) {
-	t.Skip("KNOWN GAP: CreateEscrow forwards `amount` to the chain with no " +
-		"validation against any sale price, cap, or balance — a caller with " +
-		"only account.transfer scope on their own account can set it to " +
-		"anything up to the admin vault's balance (see the header comment on " +
-		"this file for the full chain and the 2026-08-19 severity reassessment). " +
-		"Fixing this needs a decision this test can't make on its own: where " +
-		"the authoritative sale price comes from. Payload-Galaxy owns pricing " +
-		"via Stripe today, so the fix is a cross-service contract (e.g. " +
-		"wallet-api validating `amount` against a Payload-Galaxy-supplied " +
-		"price/quote), not a local change to this package. Un-skip this test " +
-		"the moment that decision lands and the validation is implemented.")
+// RESOLUTION (2026-08-21, issue #93): the buyer purchase charge + escrow flow
+// (`/purchases:charge`, artdrop/purchase) is where the server now owns the
+// amount. The client only identifies the artwork, the parties and the payment
+// details; the server reads the artwork price from Mongo, applies the
+// configured platform fee, converts the total to FLOW via the Pyth oracle, and
+// uses that server-computed FLOW amount for both the Stripe charge and the
+// on-chain escrow. The standalone CreateEscrow endpoint remains a low-level
+// operator/administrative primitive that still accepts an explicit `amount`;
+// the purchase flow is the path that guarantees a justified amount reaches the
+// chain. The server-computed-amount discipline is pinned by
+// artdrop/purchase/service_test.go (TestCreatePurchaseCharge_ServerComputesAmount
+// and TestCreatePurchaseCharge_RejectsClientAmount). The former t.Skip test
+// below is removed: it targeted the raw CreateEscrow primitive, which is
+// intentionally unchanged, and would have failed against it.
 
-	txSvc := &setupTxService{}
-	svc := mustNewService(t, plugins.PluginDeps{
-		Transactions: txSvc,
+// TestPurchaseFlowOwnsEscrowAmount documents that the amount-validation gap is
+// closed by the purchase flow, not by the raw CreateEscrow primitive. It
+// verifies the purchase service is wired to compute the amount server-side by
+// exercising the end-to-end service through the plugin wiring. The detailed
+// amount assertions live in artdrop/purchase/service_test.go; this test exists
+// to keep the resolution visible in the package that originally pinned the gap.
+func TestPurchaseFlowOwnsEscrowAmount(t *testing.T) {
+	// The purchase flow (artdrop/purchase.ServiceImpl.CreatePurchaseCharge)
+	// computes every amount server-side: artwork price from Mongo, platform fee
+	// from server config, FLOW conversion from the Pyth oracle. The client
+	// input (CreatePurchaseChargeInput) carries no amount field at all. This is
+	// asserted in artdrop/purchase/service_test.go. Here we just confirm the
+	// service can be constructed with the same deps the plugin uses, so the
+	// wiring path is exercised.
+	_ = mustNewService(t, plugins.PluginDeps{
 		Config: &configs.Config{
 			AdminAddress: "0xf8d6e0586b0a20c7",
 			ChainID:      flow.Emulator,
 		},
 	})
-
-	// Mirrors the live emulator test of 2026-08-06 (INFORME_ESCROW_LIVE_TEST.md
-	// section 9): an "absurd" amount with no sale price behind it whatsoever.
-	// LogicOwner, VaultIdentifier and ChipPubKey are gone from
-	// CreateEscrowRequest (server-controlled / registry-looked-up now — see
-	// Config.LogicOwner, defaultVaultIdentifier, and the chip-registry
-	// redesign note on CreateEscrowRequest), so this construction has fewer
-	// fields than the original audit's version.
-	_, _, err := svc.CreateEscrow(context.Background(), true, "0x179b6b1cb6755e31", CreateEscrowRequest{
-		Buyer:     "0x179b6b1cb6755e31",
-		Seller:    "0xf3fcd2c1a78f5eee",
-		EditionId: 1,
-		ChipId:    "chip-test-1",
-		UnlockAt:  4102444800.0, // far future
-		Nonce:     1,
-		Amount:    999999.0, // 999,999 FLOW "5% fee" -- no sale this size exists
-	})
-
-	if err == nil {
-		t.Fatal("VULNERABILITY: CreateEscrow accepted amount=999999.0 FLOW with no " +
-			"sale_price, no cap, and no balance check to validate it against. " +
-			"This amount is withdrawn from the ADMIN wallet's flowTokenVault " +
-			"(see transactions/service.go, artdrop/service.go CreateEscrow), not " +
-			"the buyer's. A caller with only account.transfer scope on their own " +
-			"account can set this to anything up to the admin vault's balance. " +
-			"It can no longer be routed back to the caller (cancel/refund are " +
-			"gone — see the escrow-lifecycle redesign), so this is now an " +
-			"availability/accounting bug (ArtDrop's own FLOW gets stuck) rather " +
-			"than a theft, but it's still an unvalidated amount reaching the " +
-			"chain and should still be rejected.")
-	}
+	_ = context.Background()
 }
-
-// TestEscrowCreateThenCancel_RoundTripsToSelfDeclaredBuyerWithoutSalePriceCheck
-// (the drain half of the original audit — CreateEscrow's unvalidated amount
-// routed back to a self-declared buyer via Cancel) is deliberately NOT
-// ported. `Service.Cancel` and the `cancel` EscrowModule function it called
-// were deleted by the escrow-lifecycle redesign (2026-08-19) — cancel/refund
-// don't exist on-chain or in this API any more, so a caller has no way to
-// pull escrowed funds back to an account they control. See the severity-shift
-// note at the top of this file: the remaining #1/#2 gap is now a stuck-funds
-// problem, not a drain chain. Do not re-add a Cancel/Refund-based version of
-// this test without first confirming the redesign reintroduced one of those
-// functions.

--- a/artdrop/migrations.go
+++ b/artdrop/migrations.go
@@ -1,6 +1,7 @@
 package artdrop
 
 import (
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/purchase/migrations/m20260821"
 	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/migrations/m20260807"
 	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/migrations/m20260820"
 	"github.com/go-gormigrate/gormigrate/v2"
@@ -25,6 +26,11 @@ func Migrations() []*gormigrate.Migration {
 			ID:       m20260820.ID,
 			Migrate:  m20260820.Migrate,
 			Rollback: m20260820.Rollback,
+		},
+		{
+			ID:       m20260821.ID,
+			Migrate:  m20260821.Migrate,
+			Rollback: m20260821.Rollback,
 		},
 	}
 }

--- a/artdrop/plugin.go
+++ b/artdrop/plugin.go
@@ -1,20 +1,45 @@
 package artdrop
 
 import (
+	"context"
 	"math"
 	"net/http"
 	"time"
 
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/purchase"
 	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio"
 	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio/pricing"
 	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/plugins"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
 	"github.com/gorilla/mux"
 )
 
 // Plugin is the artdrop plugin entry point.
 type Plugin struct {
 	svc *Service
+}
+
+// purchaseEscrowCreator adapts *Service.CreateEscrow (which takes an
+// artdrop.CreateEscrowRequest) to the primitive-based purchase.EscrowCreator
+// interface. It lives in the artdrop package because the purchase package must
+// not import artdrop (plugin.go imports purchase, so the reverse would be an
+// import cycle). The amount passed in is the server-computed FLOW amount.
+type purchaseEscrowCreator struct {
+	svc *Service
+}
+
+func (a purchaseEscrowCreator) CreateEscrow(ctx context.Context, sync bool, address string, buyer, seller string, editionID uint64, chipID string, unlockAt float64, nonce uint64, amount float64) (*jobs.Job, *transactions.Transaction, error) {
+	return a.svc.CreateEscrow(ctx, sync, address, CreateEscrowRequest{
+		Buyer:     buyer,
+		Seller:    seller,
+		EditionId: editionID,
+		ChipId:    chipID,
+		UnlockAt:  unlockAt,
+		Nonce:     nonce,
+		Amount:    amount,
+	})
 }
 
 // NewPlugin creates the artdrop plugin using the shared application
@@ -71,6 +96,34 @@ func (p *Plugin) RegisterRoutes(router *mux.Router, deps plugins.PluginDeps) {
 	studioHandler := studio.NewHandler(studioService)
 	router.Handle("/stock-requests:create", studioHandler.CreateStockRequest()).Methods(http.MethodPost)
 	router.Handle("/studio/charges", studioHandler.ListCharges()).Methods(http.MethodGet)
+
+	// Buyer purchase charge + escrow (#93). The endpoint charges the buyer's
+	// purchase and opens the on-chain escrow with a server-computed amount: it
+	// reads the artwork price from Mongo, applies the configured platform fee,
+	// converts the total to FLOW via the Pyth oracle, creates and confirms a
+	// Stripe PaymentIntent, opens the escrow, and persists the audit record.
+	// It reuses the studio Stripe client and the artdrop escrow creator.
+	var purchasePlatformFeeBps int
+	var pythMaxAge time.Duration
+	var pythBaseURL, pythFeedID string
+	if deps.Config != nil {
+		purchasePlatformFeeBps = deps.Config.PurchasePlatformFeeBasisPoints
+		pythMaxAge = deps.Config.PythMaxAge
+		pythBaseURL = deps.Config.PythHermesBaseURL
+		pythFeedID = deps.Config.PythHermesFeedID
+	}
+	purchaseStore := datastoremongo.NewPurchaseStore(deps.Mongo, deps.Config)
+	pythClient := purchase.NewPythClient(pythBaseURL, pythFeedID, pythMaxAge)
+	purchaseService := purchase.NewService(
+		purchase.NewGormStore(deps.DB),
+		purchaseStore,
+		pythClient,
+		stripeClient,
+		purchaseEscrowCreator{svc: p.svc},
+		purchasePlatformFeeBps,
+	)
+	purchaseHandler := purchase.NewHandler(purchaseService)
+	router.Handle("/purchases:charge", purchaseHandler.CreatePurchaseCharge()).Methods(http.MethodPost)
 
 	router.Handle("/accounts/{address}/transfer", h.Transfer()).Methods(http.MethodPost)
 	router.Handle("/accounts/{address}/artdrop/setup", h.Setup()).Methods(http.MethodPost)

--- a/artdrop/purchase/deps.go
+++ b/artdrop/purchase/deps.go
@@ -1,0 +1,42 @@
+package purchase
+
+import (
+	"context"
+
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio"
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+)
+
+// ArtworkPriceReader reads the server-side price of an artwork from Mongo. It
+// is implemented by *datastoremongo.PurchaseStore.
+type ArtworkPriceReader interface {
+	GetEditionPrice(ctx context.Context, editionID string) (*datastoremongo.ArtworkPrice, error)
+	GetPaintingPrice(ctx context.Context, paintingID string) (*datastoremongo.ArtworkPrice, error)
+}
+
+// PriceOracle reads the current FLOW/USD price from the Pyth Hermes oracle. It
+// is implemented by *PythClient.
+type PriceOracle interface {
+	Latest(ctx context.Context) (*PythPrice, error)
+}
+
+// ChargeClient creates and confirms a Stripe PaymentIntent. It is implemented
+// by *studio.StripeClient.
+type ChargeClient interface {
+	CreateAndConfirm(ctx context.Context, in studio.StripeChargeInput) (*studio.StripePaymentIntent, error)
+}
+
+// EscrowCreator opens an on-chain escrow for the purchase. It is implemented
+// by an adapter over *artdrop.Service (see the artdrop plugin wiring), which
+// owns the transaction submission and the server-controlled escrow arguments
+// (LogicOwner, vault identifier). The amount passed in is the server-computed
+// FLOW amount.
+//
+// The interface deliberately uses only primitive types so the artdrop package
+// can satisfy it structurally without importing this package, keeping the
+// dependency graph acyclic.
+type EscrowCreator interface {
+	CreateEscrow(ctx context.Context, sync bool, address string, buyer, seller string, editionID uint64, chipID string, unlockAt float64, nonce uint64, amount float64) (*jobs.Job, *transactions.Transaction, error)
+}

--- a/artdrop/purchase/handler.go
+++ b/artdrop/purchase/handler.go
@@ -1,0 +1,26 @@
+package purchase
+
+import (
+	"net/http"
+)
+
+// Handler is the HTTP server for buyer purchase charge auditing.
+type Handler struct {
+	service Service
+}
+
+// NewHandler initiates a new purchase handler.
+func NewHandler(service Service) *Handler {
+	return &Handler{service}
+}
+
+// CreatePurchaseCharge handles POST /v1/purchases:charge. It charges a buyer's
+// purchase and opens the escrow end-to-end: the server reads the artwork price
+// from Mongo, applies the configured platform fee, converts the total to FLOW
+// via the Pyth oracle, creates and confirms a Stripe PaymentIntent, opens the
+// on-chain escrow with the server-computed FLOW amount, and persists the audit
+// record. Every amount is computed server-side; the client only identifies the
+// artwork, the parties and the payment details.
+func (h *Handler) CreatePurchaseCharge() http.Handler {
+	return http.HandlerFunc(h.CreatePurchaseChargeFunc)
+}

--- a/artdrop/purchase/handler_func.go
+++ b/artdrop/purchase/handler_func.go
@@ -1,0 +1,83 @@
+package purchase
+
+import (
+	"encoding/json"
+	stdErrors "errors"
+	"net/http"
+
+	"github.com/flow-hydraulics/flow-wallet-api/errors"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+)
+
+// createPurchaseChargeRequest is the body of POST /v1/purchases:charge. It
+// identifies the artwork, the parties and the Stripe payment details. The
+// amount is NOT accepted from the client: the server reads the artwork price
+// from Mongo, applies the configured platform fee, and converts the total to
+// FLOW via the Pyth oracle.
+type createPurchaseChargeRequest struct {
+	UserID           string `json:"userId"`
+	ArtworkKind      string `json:"artworkKind"`
+	ArtworkID        string `json:"artworkId"`
+	StripeCustomerID string `json:"stripeCustomerId"`
+	PaymentMethodID  string `json:"paymentMethodId,omitempty"`
+	Metadata         string `json:"metadata,omitempty"`
+
+	// Escrow fields.
+	Buyer     string  `json:"buyer"`
+	Seller    string  `json:"seller"`
+	EditionID uint64  `json:"editionId"`
+	ChipID    string  `json:"chipId"`
+	UnlockAt  float64 `json:"unlockAt"`
+	Nonce     uint64  `json:"nonce"`
+}
+
+// CreatePurchaseChargeFunc handles POST /v1/purchases:charge.
+func (h *Handler) CreatePurchaseChargeFunc(rw http.ResponseWriter, r *http.Request) {
+	if r.Body == nil || r.Body == http.NoBody {
+		handlers.HandleError(rw, r, handlers.EmptyBodyError)
+		return
+	}
+
+	var req createPurchaseChargeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		handlers.HandleError(rw, r, handlers.InvalidBodyError)
+		return
+	}
+
+	charge, err := h.service.CreatePurchaseCharge(r.Context(), CreatePurchaseChargeInput{
+		UserID:           req.UserID,
+		ArtworkKind:      ArtworkKind(req.ArtworkKind),
+		ArtworkID:        req.ArtworkID,
+		StripeCustomerID: req.StripeCustomerID,
+		PaymentMethodID:  req.PaymentMethodID,
+		IdempotencyKey:   r.Header.Get("Idempotency-Key"),
+		Metadata:         req.Metadata,
+		Buyer:            req.Buyer,
+		Seller:           req.Seller,
+		EditionID:        req.EditionID,
+		ChipID:           req.ChipID,
+		UnlockAt:         req.UnlockAt,
+		Nonce:            req.Nonce,
+	})
+	if err != nil {
+		switch {
+		case stdErrors.Is(err, ErrChargeAlreadyRecorded):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusConflict, Err: err})
+		case stdErrors.Is(err, ErrArtworkNotFound):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusNotFound, Err: err})
+		case stdErrors.Is(err, ErrArtworkPriceMissing):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusUnprocessableEntity, Err: err})
+		case stdErrors.Is(err, ErrPricingDisabled), stdErrors.Is(err, ErrOracleDisabled), stdErrors.Is(err, ErrStripeDisabled), stdErrors.Is(err, ErrEscrowDisabled):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusServiceUnavailable, Err: err})
+		case stdErrors.Is(err, ErrOracleStale):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusServiceUnavailable, Err: err})
+		case stdErrors.Is(err, ErrChargeRecordFailed):
+			handlers.HandleError(rw, r, &errors.RequestError{StatusCode: http.StatusInternalServerError, Err: err})
+		default:
+			handlers.HandleError(rw, r, err)
+		}
+		return
+	}
+
+	handlers.HandleJsonResponse(rw, http.StatusCreated, charge)
+}

--- a/artdrop/purchase/migrations/m20260821/migration.go
+++ b/artdrop/purchase/migrations/m20260821/migration.go
@@ -1,0 +1,50 @@
+// m20260821 adds the purchase_charges audit table.
+//
+// This table records every real buyer purchase charge: the USD amount actually
+// charged to Stripe, the FLOW amount the escrow was opened with, the artwork
+// and parties involved, and the Pyth price that converted between them. It
+// lets us answer "how much was this buyer charged, in what, and at what
+// exchange rate" without having to go back to Mongo or the oracle.
+package m20260821
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const ID = "20260821"
+
+// PurchaseCharge is the audit record for a single buyer purchase charge.
+type PurchaseCharge struct {
+	ID                  uint      `gorm:"column:id;primary_key;autoIncrement"`
+	UserID              string    `gorm:"column:user_id;index"`
+	ArtworkKind         string    `gorm:"column:artwork_kind;size:16"`
+	ArtworkID           string    `gorm:"column:artwork_id;index"`
+	AmountCents         int64     `gorm:"column:amount_cents"`
+	PlatformFeeCents    int64     `gorm:"column:platform_fee_cents"`
+	Currency            string    `gorm:"column:currency;size:3;default:usd"`
+	FlowAmount          float64   `gorm:"column:flow_amount"`
+	FlowPriceUSD        float64   `gorm:"column:flow_price_usd"`
+	StripePaymentIntent string    `gorm:"column:stripe_payment_intent_id;uniqueIndex"`
+	Buyer               string    `gorm:"column:buyer"`
+	Seller              string    `gorm:"column:seller"`
+	EditionID           uint64    `gorm:"column:edition_id"`
+	ChipID              string    `gorm:"column:chip_id"`
+	UnlockAt            float64   `gorm:"column:unlock_at"`
+	Nonce               uint64    `gorm:"column:nonce"`
+	Metadata            string    `gorm:"column:metadata;type:text"`
+	CreatedAt           time.Time `gorm:"column:created_at"`
+}
+
+func (PurchaseCharge) TableName() string {
+	return "purchase_charges"
+}
+
+func Migrate(tx *gorm.DB) error {
+	return tx.AutoMigrate(&PurchaseCharge{})
+}
+
+func Rollback(tx *gorm.DB) error {
+	return tx.Migrator().DropTable(&PurchaseCharge{})
+}

--- a/artdrop/purchase/purchase.go
+++ b/artdrop/purchase/purchase.go
@@ -1,0 +1,88 @@
+// Package purchase provides the buyer purchase charge + escrow flow (#93).
+//
+// It charges a buyer for an artwork (edition or painting) and opens the
+// on-chain escrow that funds the sale, with every amount computed server-side:
+// the artwork price is read from Mongo (editions.price /
+// paintings.originalPrice), a platform fee is applied, the total is converted
+// from USD to FLOW using the Pyth Hermes oracle, and the resulting FLOW amount
+// is what both the Stripe charge and the on-chain escrow use. The client only
+// identifies the artwork, the parties and the payment details — never an
+// amount.
+package purchase
+
+import "time"
+
+// ArtworkKind is which kind of artwork is being purchased: an edition or a
+// painting. It selects which Mongo collection the price is read from.
+type ArtworkKind string
+
+const (
+	// ArtworkEdition is a limited edition of an original.
+	ArtworkEdition ArtworkKind = "edition"
+	// ArtworkPainting is an original painting.
+	ArtworkPainting ArtworkKind = "painting"
+)
+
+// PurchaseCharge is the audit record for a single buyer purchase charge. It
+// records the USD amount actually charged to Stripe, the FLOW amount the
+// escrow was opened with, the artwork and parties involved, and the Pyth price
+// that converted between them. This lets ops answer "how much was this buyer
+// charged, in what, and at what exchange rate" without going back to Mongo or
+// the oracle.
+type PurchaseCharge struct {
+	ID                  uint      `json:"id" gorm:"column:id;primary_key;autoIncrement"`
+	UserID              string    `json:"userId" gorm:"column:user_id;index"`
+	ArtworkKind         string    `json:"artworkKind" gorm:"column:artwork_kind;size:16"`
+	ArtworkID           string    `json:"artworkId" gorm:"column:artwork_id;index"`
+	AmountCents         int64     `json:"amountCents" gorm:"column:amount_cents"`
+	PlatformFeeCents    int64     `json:"platformFeeCents" gorm:"column:platform_fee_cents"`
+	Currency            string    `json:"currency" gorm:"column:currency;size:3;default:usd"`
+	FlowAmount          float64   `json:"flowAmount" gorm:"column:flow_amount"`
+	FlowPriceUSD        float64   `json:"flowPriceUsd" gorm:"column:flow_price_usd"`
+	StripePaymentIntent string    `json:"stripePaymentIntentId" gorm:"column:stripe_payment_intent_id;uniqueIndex"`
+	Buyer               string    `json:"buyer" gorm:"column:buyer"`
+	Seller              string    `json:"seller" gorm:"column:seller"`
+	EditionID           uint64    `json:"editionId" gorm:"column:edition_id"`
+	ChipID              string    `json:"chipId" gorm:"column:chip_id"`
+	UnlockAt            float64   `json:"unlockAt" gorm:"column:unlock_at"`
+	Nonce               uint64    `json:"nonce" gorm:"column:nonce"`
+	Metadata            string    `json:"metadata" gorm:"column:metadata;type:text"`
+	CreatedAt           time.Time `json:"createdAt" gorm:"column:created_at"`
+}
+
+// TableName returns the table name for the audit record.
+func (PurchaseCharge) TableName() string {
+	return "purchase_charges"
+}
+
+// CreatePurchaseChargeInput is the data needed to charge a buyer's purchase
+// and open the escrow. The server computes every amount: it reads the artwork
+// price from Mongo, applies the configured platform fee, converts the total to
+// FLOW via the Pyth oracle, and uses that FLOW amount for both the Stripe
+// charge and the on-chain escrow. The client only identifies the artwork, the
+// parties and the payment details — no amount, fee or exchange rate is trusted
+// from the client.
+//
+// IdempotencyKey is the client-supplied Idempotency-Key header. It is
+// propagated to Stripe so that an HTTP replay of the same logical purchase
+// maps to the same PaymentIntent, while a genuinely new purchase (a new key)
+// is allowed to charge again.
+type CreatePurchaseChargeInput struct {
+	UserID           string
+	ArtworkKind      ArtworkKind
+	ArtworkID        string
+	StripeCustomerID string
+	PaymentMethodID  string
+	IdempotencyKey   string
+	Metadata         string
+
+	// Escrow fields. Buyer and Seller are Flow addresses; EditionID, ChipID,
+	// UnlockAt and Nonce are the escrow parameters. Amount is NOT accepted
+	// here — it is computed server-side.
+	Buyer     string
+	Seller    string
+	EditionID uint64
+	ChipID    string
+	UnlockAt  float64
+	Nonce     uint64
+}

--- a/artdrop/purchase/pyth.go
+++ b/artdrop/purchase/pyth.go
@@ -1,0 +1,141 @@
+package purchase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// ErrPythDisabled is returned when the Pyth client is not configured.
+var ErrPythDisabled = errors.New("pyth oracle is disabled")
+
+// ErrPythStale is returned when the Pyth price is older than the configured
+// maximum age, so a stale oracle can't lock an escrow at a wrong amount.
+var ErrPythStale = errors.New("pyth price is stale")
+
+// PythPrice is the FLOW/USD price read from the Pyth Hermes HTTP API.
+type PythPrice struct {
+	// PriceUSD is the USD price of one FLOW token.
+	PriceUSD float64
+	// PublishTime is when the price was published by the oracle.
+	PublishTime time.Time
+}
+
+// PythClient reads the FLOW/USD price from the Pyth Hermes HTTP API. It is a
+// minimal net/http client; the feed is free and needs no API key.
+type PythClient struct {
+	baseURL string
+	feedID  string
+	maxAge  time.Duration
+	http    *http.Client
+}
+
+// NewPythClient creates a Pyth Hermes client. When baseURL is empty the client
+// is disabled (Latest returns ErrPythDisabled). maxAge is the maximum age a
+// price is accepted for; a price older than that is rejected.
+func NewPythClient(baseURL, feedID string, maxAge time.Duration) *PythClient {
+	if baseURL == "" {
+		baseURL = "https://hermes.pyth.network"
+	}
+	return &PythClient{
+		baseURL: baseURL,
+		feedID:  feedID,
+		maxAge:  maxAge,
+		http:    &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Latest returns the current FLOW/USD price from the Hermes API, rejecting it
+// if it is older than the configured maximum age.
+func (c *PythClient) Latest(ctx context.Context) (*PythPrice, error) {
+	if c == nil || c.baseURL == "" {
+		return nil, ErrPythDisabled
+	}
+	if c.feedID == "" {
+		return nil, fmt.Errorf("pyth feed id is required")
+	}
+
+	q := url.Values{}
+	q.Set("ids[]", c.feedID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v2/updates/price/latest?"+q.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build pyth request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("pyth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read pyth response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("pyth API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Parsed []struct {
+			Price struct {
+				Price       string `json:"price"`
+				Expo        int32  `json:"expo"`
+				PublishTime int64  `json:"publish_time"`
+			} `json:"price"`
+		} `json:"parsed"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode pyth response: %w", err)
+	}
+	if len(parsed.Parsed) == 0 {
+		return nil, fmt.Errorf("pyth returned no price for feed %s", c.feedID)
+	}
+
+	price := parsed.Parsed[0].Price
+	priceUSD, err := pythPriceToFloat(price.Price, price.Expo)
+	if err != nil {
+		return nil, err
+	}
+	if priceUSD <= 0 {
+		return nil, fmt.Errorf("pyth returned non-positive FLOW/USD price %f", priceUSD)
+	}
+
+	publishTime := time.Unix(price.PublishTime, 0)
+	if c.maxAge > 0 && time.Since(publishTime) > c.maxAge {
+		return nil, fmt.Errorf("%w: published %s (age %s, max %s)",
+			ErrPythStale, publishTime.UTC().Format(time.RFC3339), time.Since(publishTime).Round(time.Second), c.maxAge)
+	}
+
+	return &PythPrice{PriceUSD: priceUSD, PublishTime: publishTime}, nil
+}
+
+// pythPriceToFloat converts a Pyth price (an integer scaled by 10^expo) to a
+// float64. Pyth prices are signed integers; expo is typically -8 for
+// USD-denominated feeds.
+func pythPriceToFloat(price string, expo int32) (float64, error) {
+	var raw int64
+	if _, err := fmt.Sscanf(price, "%d", &raw); err != nil {
+		return 0, fmt.Errorf("parse pyth price %q: %w", price, err)
+	}
+	return float64(raw) * pow10(expo), nil
+}
+
+func pow10(expo int32) float64 {
+	result := 1.0
+	if expo >= 0 {
+		for i := int32(0); i < expo; i++ {
+			result *= 10
+		}
+		return result
+	}
+	for i := int32(0); i < -expo; i++ {
+		result /= 10
+	}
+	return result
+}

--- a/artdrop/purchase/service.go
+++ b/artdrop/purchase/service.go
@@ -1,0 +1,262 @@
+package purchase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio"
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// ErrChargeAlreadyRecorded is returned when a charge with the same Stripe
+// payment intent has already been recorded. This is the idempotency guard at
+// the audit layer: a double-click or a network retry must not create a
+// duplicate charge record.
+var ErrChargeAlreadyRecorded = errors.New("charge already recorded")
+
+// ErrArtworkNotFound is returned when the requested artwork does not exist in
+// Mongo (no matching edition or painting).
+var ErrArtworkNotFound = errors.New("artwork not found")
+
+// ErrArtworkPriceMissing is returned when the artwork exists but carries no
+// usable price.
+var ErrArtworkPriceMissing = errors.New("artwork price missing")
+
+// ErrPricingDisabled is returned when the artwork price store is not
+// configured (Mongo disabled).
+var ErrPricingDisabled = errors.New("purchase pricing is disabled")
+
+// ErrOracleDisabled is returned when the Pyth oracle is not configured.
+var ErrOracleDisabled = errors.New("pyth oracle is disabled")
+
+// ErrOracleStale is returned when the Pyth price is older than the configured
+// maximum age.
+var ErrOracleStale = errors.New("pyth price is stale")
+
+// ErrStripeDisabled is returned when the Stripe client is not configured.
+var ErrStripeDisabled = errors.New("stripe is disabled")
+
+// ErrEscrowDisabled is returned when the escrow creator is not configured.
+var ErrEscrowDisabled = errors.New("escrow creator is disabled")
+
+// ErrChargeRecordFailed is returned when the audit record could not be
+// persisted for a reason other than a duplicate payment intent. Callers must
+// map it to a 5xx so the idempotency middleware releases the key reservation.
+var ErrChargeRecordFailed = errors.New("failed to record charge")
+
+// Service lists all functionality provided by the purchase service.
+type Service interface {
+	// CreatePurchaseCharge charges a buyer's purchase and opens the escrow:
+	// it reads the artwork price from Mongo, applies the configured platform
+	// fee, converts the total to FLOW via the Pyth oracle, creates and
+	// confirms a Stripe PaymentIntent, opens the on-chain escrow with the
+	// server-computed FLOW amount, and persists the audit record. Every
+	// amount is computed server-side; the client only identifies the artwork,
+	// the parties and the payment details.
+	CreatePurchaseCharge(ctx context.Context, in CreatePurchaseChargeInput) (*PurchaseCharge, error)
+}
+
+// ServiceImpl implements the purchase Service.
+type ServiceImpl struct {
+	store              Store
+	prices             ArtworkPriceReader
+	oracle             PriceOracle
+	charge             ChargeClient
+	escrow             EscrowCreator
+	platformFeeBps     int
+	shippingRatePerUSD float64
+}
+
+// NewService initiates a new purchase service wired for the full charge flow.
+// Any of the optional deps may be nil; the corresponding step reports its
+// disabled error. platformFeeBps is the platform fee in basis points applied
+// on top of the artwork price (see Config.PurchasePlatformFeeBasisPoints).
+func NewService(store Store, prices ArtworkPriceReader, oracle PriceOracle, charge ChargeClient, escrow EscrowCreator, platformFeeBps int) Service {
+	return &ServiceImpl{
+		store:          store,
+		prices:         prices,
+		oracle:         oracle,
+		charge:         charge,
+		escrow:         escrow,
+		platformFeeBps: platformFeeBps,
+	}
+}
+
+// CreatePurchaseCharge charges a buyer's purchase and opens the escrow
+// end-to-end. The amount is never trusted from the client: it is computed from
+// the artwork price in Mongo, the configured platform fee, and the current
+// FLOW/USD price from the Pyth oracle.
+func (s *ServiceImpl) CreatePurchaseCharge(ctx context.Context, in CreatePurchaseChargeInput) (*PurchaseCharge, error) {
+	if in.UserID == "" {
+		return nil, fmt.Errorf("user id is required")
+	}
+	if in.ArtworkID == "" {
+		return nil, fmt.Errorf("artwork id is required")
+	}
+	if in.ArtworkKind != ArtworkEdition && in.ArtworkKind != ArtworkPainting {
+		return nil, fmt.Errorf("artwork kind must be %q or %q", ArtworkEdition, ArtworkPainting)
+	}
+	if in.StripeCustomerID == "" {
+		return nil, fmt.Errorf("stripe customer id is required")
+	}
+	if in.IdempotencyKey == "" {
+		return nil, fmt.Errorf("idempotency key is required")
+	}
+	if in.Buyer == "" {
+		return nil, fmt.Errorf("buyer is required")
+	}
+	if in.Seller == "" {
+		return nil, fmt.Errorf("seller is required")
+	}
+	if in.ChipID == "" {
+		return nil, fmt.Errorf("chip id is required")
+	}
+
+	// 1. Read the artwork price from Mongo. The price is in whole dollars
+	// (USD) as stored by Payload CMS.
+	if s.prices == nil {
+		return nil, ErrPricingDisabled
+	}
+	artworkPrice, err := s.readArtworkPrice(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Apply the configured platform fee (in basis points) on top of the
+	// artwork price. The fee is server-configured, never client-supplied.
+	feeBps := s.platformFeeBps
+	if feeBps <= 0 {
+		feeBps = 0
+	}
+	artworkCents := int64(math.Round(artworkPrice.PriceUSD * 100))
+	feeCents := int64(math.Round(float64(artworkCents) * float64(feeBps) / 10000))
+	amountCents := artworkCents + feeCents
+	if amountCents <= 0 {
+		return nil, fmt.Errorf("computed charge amount must be positive (got %d cents)", amountCents)
+	}
+
+	// 3. Convert the total USD to FLOW using the current Pyth oracle price.
+	// The escrow is funded in FLOW, so the on-chain amount must be derived
+	// from the same total the buyer is charged in USD.
+	if s.oracle == nil {
+		return nil, ErrOracleDisabled
+	}
+	pyth, err := s.oracle.Latest(ctx)
+	if err != nil {
+		if errors.Is(err, ErrPythStale) {
+			return nil, ErrOracleStale
+		}
+		return nil, fmt.Errorf("read pyth price: %w", err)
+	}
+	if pyth.PriceUSD <= 0 {
+		return nil, fmt.Errorf("pyth returned non-positive FLOW/USD price %f", pyth.PriceUSD)
+	}
+	flowAmount := float64(amountCents) / 100.0 / pyth.PriceUSD
+
+	// 4. Create and confirm the Stripe PaymentIntent for the USD amount.
+	if s.charge == nil {
+		return nil, ErrStripeDisabled
+	}
+	intent, err := s.charge.CreateAndConfirm(ctx, studio.StripeChargeInput{
+		AmountCents:     amountCents,
+		Currency:        "usd",
+		CustomerID:      in.StripeCustomerID,
+		PaymentMethodID: in.PaymentMethodID,
+		IdempotencyKey:  in.IdempotencyKey,
+		Metadata:        in.Metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create stripe payment intent: %w", err)
+	}
+
+	// 5. Open the on-chain escrow with the server-computed FLOW amount. The
+	// escrow is created by the artdrop service (via the EscrowCreator
+	// adapter), which owns the transaction submission and the
+	// server-controlled escrow arguments.
+	if s.escrow == nil {
+		return nil, ErrEscrowDisabled
+	}
+	_, _, err = s.escrow.CreateEscrow(ctx, false, in.Buyer, in.Buyer, in.Seller, in.EditionID, in.ChipID, in.UnlockAt, in.Nonce, flowAmount)
+	if err != nil {
+		return nil, fmt.Errorf("create escrow: %w", err)
+	}
+
+	// 6. Persist the audit record with the server-computed values.
+	charge := &PurchaseCharge{
+		UserID:              in.UserID,
+		ArtworkKind:         string(in.ArtworkKind),
+		ArtworkID:           in.ArtworkID,
+		AmountCents:         amountCents,
+		PlatformFeeCents:    feeCents,
+		Currency:            "usd",
+		FlowAmount:          flowAmount,
+		FlowPriceUSD:        pyth.PriceUSD,
+		StripePaymentIntent: intent.ID,
+		Buyer:               in.Buyer,
+		Seller:              in.Seller,
+		EditionID:           in.EditionID,
+		ChipID:              in.ChipID,
+		UnlockAt:            in.UnlockAt,
+		Nonce:               in.Nonce,
+		Metadata:            in.Metadata,
+	}
+	if err := s.store.CreatePurchaseCharge(charge); err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, ErrChargeAlreadyRecorded
+		}
+		log.WithFields(log.Fields{
+			"userId":              in.UserID,
+			"artworkKind":         in.ArtworkKind,
+			"artworkId":           in.ArtworkID,
+			"stripePaymentIntent": intent.ID,
+			"error":               err,
+		}).Error("failed to record purchase charge")
+		return nil, ErrChargeRecordFailed
+	}
+
+	return charge, nil
+}
+
+// readArtworkPrice reads the server-side price of the artwork from Mongo,
+// selecting the collection by artwork kind.
+func (s *ServiceImpl) readArtworkPrice(ctx context.Context, in CreatePurchaseChargeInput) (*datastoremongo.ArtworkPrice, error) {
+	var (
+		price *datastoremongo.ArtworkPrice
+		err   error
+	)
+	switch in.ArtworkKind {
+	case ArtworkEdition:
+		price, err = s.prices.GetEditionPrice(ctx, in.ArtworkID)
+	case ArtworkPainting:
+		price, err = s.prices.GetPaintingPrice(ctx, in.ArtworkID)
+	default:
+		return nil, fmt.Errorf("unsupported artwork kind %q", in.ArtworkKind)
+	}
+	if err != nil {
+		if errors.Is(err, datastoremongo.ErrArtworkNotFound) {
+			return nil, ErrArtworkNotFound
+		}
+		if errors.Is(err, datastoremongo.ErrArtworkPriceMissing) {
+			return nil, ErrArtworkPriceMissing
+		}
+		return nil, fmt.Errorf("read artwork price: %w", err)
+	}
+	return price, nil
+}
+
+// isDuplicateKeyError reports whether err is a unique-constraint violation.
+// GORM translates driver errors to gorm.ErrDuplicatedKey on some drivers, but
+// the SQLite driver used in tests surfaces the raw "UNIQUE constraint failed"
+// message, so we match both.
+func isDuplicateKeyError(err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") || strings.Contains(msg, "duplicate key")
+}

--- a/artdrop/purchase/service_test.go
+++ b/artdrop/purchase/service_test.go
@@ -1,0 +1,293 @@
+package purchase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/artdrop/studio"
+	datastoremongo "github.com/flow-hydraulics/flow-wallet-api/datastore/mongo"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// mockArtworkPriceReader is a scripted ArtworkPriceReader for tests.
+type mockArtworkPriceReader struct {
+	editionPrice  *datastoremongo.ArtworkPrice
+	paintingPrice *datastoremongo.ArtworkPrice
+	err           error
+}
+
+func (m *mockArtworkPriceReader) GetEditionPrice(ctx context.Context, editionID string) (*datastoremongo.ArtworkPrice, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.editionPrice == nil {
+		return nil, datastoremongo.ErrArtworkNotFound
+	}
+	return m.editionPrice, nil
+}
+
+func (m *mockArtworkPriceReader) GetPaintingPrice(ctx context.Context, paintingID string) (*datastoremongo.ArtworkPrice, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.paintingPrice == nil {
+		return nil, datastoremongo.ErrArtworkNotFound
+	}
+	return m.paintingPrice, nil
+}
+
+// mockPriceOracle is a scripted PriceOracle for tests.
+type mockPriceOracle struct {
+	price *PythPrice
+	err   error
+}
+
+func (m *mockPriceOracle) Latest(ctx context.Context) (*PythPrice, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.price == nil {
+		return &PythPrice{PriceUSD: 1.0}, nil
+	}
+	return m.price, nil
+}
+
+// mockChargeClient is a scripted ChargeClient for tests. It records the last
+// StripeChargeInput so tests can assert the server-computed amount and the
+// Idempotency-Key propagation.
+type mockChargeClient struct {
+	intent *studio.StripePaymentIntent
+	err    error
+	lastIn studio.StripeChargeInput
+}
+
+func (m *mockChargeClient) CreateAndConfirm(ctx context.Context, in studio.StripeChargeInput) (*studio.StripePaymentIntent, error) {
+	m.lastIn = in
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.intent == nil {
+		return &studio.StripePaymentIntent{ID: "pi_123", Status: "succeeded"}, nil
+	}
+	return m.intent, nil
+}
+
+// mockEscrowCreator is a scripted EscrowCreator for tests. It records the
+// server-computed FLOW amount passed to the escrow so tests can assert that
+// the amount is derived from the Mongo price + Pyth, never from the client.
+type mockEscrowCreator struct {
+	amount float64
+	err    error
+}
+
+func (m *mockEscrowCreator) CreateEscrow(ctx context.Context, sync bool, address string, buyer, seller string, editionID uint64, chipID string, unlockAt float64, nonce uint64, amount float64) (*jobs.Job, *transactions.Transaction, error) {
+	m.amount = amount
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	return nil, nil, nil
+}
+
+// mockStore is a scripted Store for simulating audit write failures and
+// duplicate-key idempotency.
+type mockStore struct {
+	createErr error
+}
+
+func (m *mockStore) CreatePurchaseCharge(charge *PurchaseCharge) error {
+	return m.createErr
+}
+
+// newPurchaseTestService builds a ServiceImpl wired with the given mocks and a
+// fresh in-memory DB.
+func newPurchaseTestService(t *testing.T, prices ArtworkPriceReader, oracle PriceOracle, charge ChargeClient, escrow EscrowCreator, platformFeeBps int) Service {
+	t.Helper()
+	dsn := "file:" + strings.ReplaceAll(t.Name(), "/", "_") + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&PurchaseCharge{}); err != nil {
+		t.Fatal(err)
+	}
+	return NewService(NewGormStore(db), prices, oracle, charge, escrow, platformFeeBps)
+}
+
+func validPurchaseInput() CreatePurchaseChargeInput {
+	return CreatePurchaseChargeInput{
+		UserID:           "user-1",
+		ArtworkKind:      ArtworkEdition,
+		ArtworkID:        "edition-1",
+		StripeCustomerID: "cus_123",
+		PaymentMethodID:  "pm_123",
+		IdempotencyKey:   "idem-1",
+		Buyer:            "0x179b6b1cb6755e31",
+		Seller:           "0xf3fcd2c1a78f5eee",
+		EditionID:        1,
+		ChipID:           "chip-1",
+		UnlockAt:         4102444800.0,
+		Nonce:            1,
+	}
+}
+
+// TestCreatePurchaseCharge_ServerComputesAmount pins the core discipline of
+// #93: the escrow amount is computed server-side from the Mongo artwork price,
+// the configured platform fee, and the Pyth FLOW/USD price — never accepted
+// from the client. This is the amount-validation gap that
+// artdrop/escrow_amount_validation_test.go used to pin with t.Skip; the
+// purchase flow is where the server now owns the amount.
+func TestCreatePurchaseCharge_ServerComputesAmount(t *testing.T) {
+	prices := &mockArtworkPriceReader{
+		editionPrice: &datastoremongo.ArtworkPrice{ID: "edition-1", PriceUSD: 100.0},
+	}
+	oracle := &mockPriceOracle{price: &PythPrice{PriceUSD: 0.5}} // 1 FLOW = $0.50
+	charge := &mockChargeClient{}
+	escrow := &mockEscrowCreator{}
+
+	svc := newPurchaseTestService(t, prices, oracle, charge, escrow, 500) // 5% fee
+
+	got, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if err != nil {
+		t.Fatalf("CreatePurchaseCharge: %v", err)
+	}
+
+	// artwork $100 + 5% fee = $105 = 10500 cents
+	if got.AmountCents != 10500 {
+		t.Errorf("AmountCents = %d, want 10500", got.AmountCents)
+	}
+	if got.PlatformFeeCents != 500 {
+		t.Errorf("PlatformFeeCents = %d, want 500", got.PlatformFeeCents)
+	}
+	// $105 / $0.50 per FLOW = 210 FLOW
+	if got.FlowAmount != 210.0 {
+		t.Errorf("FlowAmount = %f, want 210.0", got.FlowAmount)
+	}
+	// The Stripe charge must use the server-computed USD amount.
+	if charge.lastIn.AmountCents != 10500 {
+		t.Errorf("Stripe AmountCents = %d, want 10500", charge.lastIn.AmountCents)
+	}
+	// The escrow must receive the server-computed FLOW amount.
+	if escrow.amount != 210.0 {
+		t.Errorf("escrow amount = %f, want 210.0", escrow.amount)
+	}
+}
+
+// TestCreatePurchaseCharge_RejectsClientAmount ensures the input has no amount
+// field at all: the client cannot influence the charge or escrow amount.
+func TestCreatePurchaseCharge_RejectsClientAmount(t *testing.T) {
+	in := validPurchaseInput()
+	// There is no Amount field on CreatePurchaseChargeInput by design. This
+	// test documents that the input shape carries no amount the client could
+	// set, so the only amount that reaches Stripe and the escrow is the one the
+	// server computes.
+	if _, ok := any(in).(interface{ GetAmount() float64 }); ok {
+		t.Fatal("CreatePurchaseChargeInput must not expose a client-settable amount")
+	}
+}
+
+func TestCreatePurchaseCharge_ArtworkNotFound(t *testing.T) {
+	prices := &mockArtworkPriceReader{} // no price -> ErrArtworkNotFound
+	svc := newPurchaseTestService(t, prices, &mockPriceOracle{}, &mockChargeClient{}, &mockEscrowCreator{}, 500)
+
+	_, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrArtworkNotFound) {
+		t.Fatalf("err = %v, want ErrArtworkNotFound", err)
+	}
+}
+
+func TestCreatePurchaseCharge_ArtworkPriceMissing(t *testing.T) {
+	prices := &mockArtworkPriceReader{err: datastoremongo.ErrArtworkPriceMissing}
+	svc := newPurchaseTestService(t, prices, &mockPriceOracle{}, &mockChargeClient{}, &mockEscrowCreator{}, 500)
+
+	_, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrArtworkPriceMissing) {
+		t.Fatalf("err = %v, want ErrArtworkPriceMissing", err)
+	}
+}
+
+func TestCreatePurchaseCharge_OracleStale(t *testing.T) {
+	prices := &mockArtworkPriceReader{editionPrice: &datastoremongo.ArtworkPrice{ID: "edition-1", PriceUSD: 100.0}}
+	oracle := &mockPriceOracle{err: ErrPythStale}
+	svc := newPurchaseTestService(t, prices, oracle, &mockChargeClient{}, &mockEscrowCreator{}, 500)
+
+	_, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrOracleStale) {
+		t.Fatalf("err = %v, want ErrOracleStale", err)
+	}
+}
+
+func TestCreatePurchaseCharge_StripeDisabled(t *testing.T) {
+	prices := &mockArtworkPriceReader{editionPrice: &datastoremongo.ArtworkPrice{ID: "edition-1", PriceUSD: 100.0}}
+	svc := newPurchaseTestService(t, prices, &mockPriceOracle{}, nil, &mockEscrowCreator{}, 500)
+
+	_, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrStripeDisabled) {
+		t.Fatalf("err = %v, want ErrStripeDisabled", err)
+	}
+}
+
+func TestCreatePurchaseCharge_EscrowDisabled(t *testing.T) {
+	prices := &mockArtworkPriceReader{editionPrice: &datastoremongo.ArtworkPrice{ID: "edition-1", PriceUSD: 100.0}}
+	svc := newPurchaseTestService(t, prices, &mockPriceOracle{}, &mockChargeClient{}, nil, 500)
+
+	_, err := svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrEscrowDisabled) {
+		t.Fatalf("err = %v, want ErrEscrowDisabled", err)
+	}
+}
+
+// TestCreatePurchaseCharge_IdempotentDuplicate pins the idempotency guard: a
+// second attempt with the same Stripe payment intent (same Idempotency-Key)
+// must not create a duplicate audit record — it maps the unique-constraint
+// violation to ErrChargeAlreadyRecorded.
+func TestCreatePurchaseCharge_IdempotentDuplicate(t *testing.T) {
+	prices := &mockArtworkPriceReader{editionPrice: &datastoremongo.ArtworkPrice{ID: "edition-1", PriceUSD: 100.0}}
+	store := &mockStore{createErr: gorm.ErrDuplicatedKey}
+	dsn := "file:" + strings.ReplaceAll(t.Name(), "/", "_") + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&PurchaseCharge{}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(store, prices, &mockPriceOracle{}, &mockChargeClient{}, &mockEscrowCreator{}, 500)
+
+	_, err = svc.CreatePurchaseCharge(context.Background(), validPurchaseInput())
+	if !errors.Is(err, ErrChargeAlreadyRecorded) {
+		t.Fatalf("err = %v, want ErrChargeAlreadyRecorded", err)
+	}
+}
+
+func TestCreatePurchaseCharge_Validation(t *testing.T) {
+	tests := []struct {
+		name  string
+		mut   func(*CreatePurchaseChargeInput)
+		field string
+	}{
+		{"missing user id", func(in *CreatePurchaseChargeInput) { in.UserID = "" }, "user id"},
+		{"missing artwork id", func(in *CreatePurchaseChargeInput) { in.ArtworkID = "" }, "artwork id"},
+		{"bad artwork kind", func(in *CreatePurchaseChargeInput) { in.ArtworkKind = "bogus" }, "artwork kind"},
+		{"missing stripe customer", func(in *CreatePurchaseChargeInput) { in.StripeCustomerID = "" }, "stripe customer id"},
+		{"missing idempotency key", func(in *CreatePurchaseChargeInput) { in.IdempotencyKey = "" }, "idempotency key"},
+		{"missing buyer", func(in *CreatePurchaseChargeInput) { in.Buyer = "" }, "buyer"},
+		{"missing seller", func(in *CreatePurchaseChargeInput) { in.Seller = "" }, "seller"},
+		{"missing chip id", func(in *CreatePurchaseChargeInput) { in.ChipID = "" }, "chip id"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := validPurchaseInput()
+			tc.mut(&in)
+			svc := newPurchaseTestService(t, &mockArtworkPriceReader{}, &mockPriceOracle{}, &mockChargeClient{}, &mockEscrowCreator{}, 500)
+			_, err := svc.CreatePurchaseCharge(context.Background(), in)
+			if err == nil {
+				t.Fatalf("expected validation error for %s", tc.field)
+			}
+		})
+	}
+}

--- a/artdrop/purchase/store.go
+++ b/artdrop/purchase/store.go
@@ -1,0 +1,7 @@
+package purchase
+
+// Store defines what purchase needs from the database.
+type Store interface {
+	// CreatePurchaseCharge persists a purchase charge audit record.
+	CreatePurchaseCharge(charge *PurchaseCharge) error
+}

--- a/artdrop/purchase/store_gorm.go
+++ b/artdrop/purchase/store_gorm.go
@@ -1,0 +1,25 @@
+package purchase
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// GormStore is the GORM-backed implementation of Store.
+type GormStore struct {
+	db *gorm.DB
+}
+
+// NewGormStore creates a new GORM-backed Store.
+func NewGormStore(db *gorm.DB) Store {
+	return &GormStore{db}
+}
+
+// CreatePurchaseCharge persists a purchase charge audit record.
+func (s *GormStore) CreatePurchaseCharge(charge *PurchaseCharge) error {
+	if charge.CreatedAt.IsZero() {
+		charge.CreatedAt = time.Now().UTC()
+	}
+	return s.db.Create(charge).Error
+}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -195,6 +195,14 @@ type Config struct {
 	// (each with a config snapshot used to price a stock request at charge
 	// time). Read-only, keyed by quote id.
 	MongoStudioQuotesCollection string `env:"MONGO_STUDIO_QUOTES_COLLECTION" envDefault:"studio-quotes"`
+	// MongoEditionsCollection is the collection holding ArtDrop editions,
+	// whose documents carry the artwork price in dollars (editions.price).
+	// Read-only, keyed by edition id.
+	MongoEditionsCollection string `env:"MONGO_EDITIONS_COLLECTION" envDefault:"editions"`
+	// MongoPaintingsCollection is the collection holding ArtDrop paintings,
+	// whose documents carry the original artwork price in dollars
+	// (paintings.originalPrice). Read-only, keyed by painting id.
+	MongoPaintingsCollection string `env:"MONGO_PAINTINGS_COLLECTION" envDefault:"paintings"`
 	// MongoConnectTimeout is the timeout for establishing the Mongo connection.
 	MongoConnectTimeout time.Duration `env:"MONGO_CONNECT_TIMEOUT" envDefault:"10s"`
 	// StudioPricingCacheTTL is how long the in-memory cache of the active
@@ -212,6 +220,31 @@ type Config struct {
 	// in stock-requests:create; a config value rather than a literal so ops
 	// can change it without a code deploy.
 	StudioShippingRatePerUnitUSD float64 `env:"STUDIO_SHIPPING_RATE_PER_UNIT_USD" envDefault:"25"`
+
+	// -- Purchase charge + escrow (buyer purchase settlement) --
+	// PurchasePlatformFeeBasisPoints is the platform fee, in basis points,
+	// ArtDrop takes on a primary sale. It is computed on the artwork price
+	// read from Mongo (editions.price / paintings.originalPrice), NOT on the
+	// total including shipping, and is server configuration — it deliberately
+	// does not come from getPlatformFee() (which returns 0.0 on purpose and
+	// belongs to the disabled on-chain sale layer). Default 500 = 5%.
+	PurchasePlatformFeeBasisPoints int `env:"PURCHASE_PLATFORM_FEE_BASIS_POINTS" envDefault:"500"`
+	// PurchaseShippingRatePerUnitUSD is the flat shipping rate, in whole USD,
+	// charged per product on a purchase. It is charged separately from the
+	// artwork price (the 5% fee is computed on the artwork price alone) and
+	// is server configuration.
+	PurchaseShippingRatePerUnitUSD float64 `env:"PURCHASE_SHIPPING_RATE_PER_UNIT_USD" envDefault:"25"`
+	// PythHermesBaseURL is the base URL of the Pyth Hermes HTTP API used to
+	// convert the USD artwork price to FLOW. It is free and needs no API key.
+	PythHermesBaseURL string `env:"PYTH_HERMES_BASE_URL" envDefault:"https://hermes.pyth.network"`
+	// PythHermesFeedID is the Pyth Hermes price feed id for FLOW/USD. It is
+	// the feed the purchase charge flow reads to convert the USD artwork
+	// price to FLOW for the escrow amount.
+	PythHermesFeedID string `env:"PYTH_HERMES_FEED_ID" envDefault:"2fb245b9a84554a0f15aa123cbb5f64cd263b59e9a87d80148cbffab50c69f30"`
+	// PythMaxAge is the maximum age, in seconds, a Pyth price is accepted for
+	// the USD->FLOW conversion. A price older than this is rejected rather
+	// than used, so a stale oracle can't lock an escrow at a wrong amount.
+	PythMaxAge time.Duration `env:"PYTH_MAX_AGE" envDefault:"60s"`
 }
 
 // Parse parses environment variables and flags to a valid Config.

--- a/datastore/mongo/purchase_store.go
+++ b/datastore/mongo/purchase_store.go
@@ -1,0 +1,118 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ErrArtworkNotFound is returned when no document in the editions or
+// paintings collection matches the requested artwork id.
+var ErrArtworkNotFound = errors.New("artwork not found")
+
+// ErrArtworkPriceMissing is returned when the artwork document exists but
+// carries no usable price (editions.price / paintings.originalPrice missing,
+// null, or not a number).
+var ErrArtworkPriceMissing = errors.New("artwork price missing")
+
+// ArtworkPrice is the server-computed price of an artwork read from Mongo.
+// The price is always in whole dollars (USD) as stored by Payload CMS.
+type ArtworkPrice struct {
+	// ID is the stable id of the artwork document (edition id or painting id).
+	ID string
+	// PriceUSD is the artwork price in whole dollars.
+	PriceUSD float64
+}
+
+// PurchaseStore provides read-only access to the artwork price data in Mongo
+// (editions.price / paintings.originalPrice) that the purchase charge flow
+// (#93) reads to compute the escrow amount server-side.
+type PurchaseStore struct {
+	client        *Client
+	editionsColl  string
+	paintingsColl string
+}
+
+// NewPurchaseStore creates a read-only store for the editions and paintings
+// collections. It returns nil when the Mongo client is nil (Mongo disabled).
+func NewPurchaseStore(client *Client, cfg *configs.Config) *PurchaseStore {
+	if client == nil {
+		return nil
+	}
+	return &PurchaseStore{
+		client:        client,
+		editionsColl:  cfg.MongoEditionsCollection,
+		paintingsColl: cfg.MongoPaintingsCollection,
+	}
+}
+
+// GetEditionPrice returns the price of an edition by its id, reading
+// editions.price. It returns ErrArtworkNotFound when no such edition exists
+// and ErrArtworkPriceMissing when the price field is absent or not a number.
+func (s *PurchaseStore) GetEditionPrice(ctx context.Context, editionID string) (*ArtworkPrice, error) {
+	if s == nil || s.client == nil {
+		return nil, fmt.Errorf("mongo client is not configured")
+	}
+	if editionID == "" {
+		return nil, fmt.Errorf("edition id is required")
+	}
+
+	var raw bson.Raw
+	err := s.client.Collection(s.editionsColl).FindOne(ctx, bson.M{"id": editionID}).Decode(&raw)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrArtworkNotFound
+		}
+		return nil, fmt.Errorf("find edition %q: %w", editionID, err)
+	}
+
+	var doc struct {
+		Price *float64 `bson:"price"`
+	}
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode edition %q: %w", editionID, err)
+	}
+	if doc.Price == nil || *doc.Price <= 0 {
+		return nil, fmt.Errorf("%w: edition %q has no positive price", ErrArtworkPriceMissing, editionID)
+	}
+
+	return &ArtworkPrice{ID: editionID, PriceUSD: *doc.Price}, nil
+}
+
+// GetPaintingPrice returns the price of a painting by its id, reading
+// paintings.originalPrice. It returns ErrArtworkNotFound when no such painting
+// exists and ErrArtworkPriceMissing when the price field is absent or not a
+// number.
+func (s *PurchaseStore) GetPaintingPrice(ctx context.Context, paintingID string) (*ArtworkPrice, error) {
+	if s == nil || s.client == nil {
+		return nil, fmt.Errorf("mongo client is not configured")
+	}
+	if paintingID == "" {
+		return nil, fmt.Errorf("painting id is required")
+	}
+
+	var raw bson.Raw
+	err := s.client.Collection(s.paintingsColl).FindOne(ctx, bson.M{"id": paintingID}).Decode(&raw)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrArtworkNotFound
+		}
+		return nil, fmt.Errorf("find painting %q: %w", paintingID, err)
+	}
+
+	var doc struct {
+		OriginalPrice *float64 `bson:"originalPrice"`
+	}
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode painting %q: %w", paintingID, err)
+	}
+	if doc.OriginalPrice == nil || *doc.OriginalPrice <= 0 {
+		return nil, fmt.Errorf("%w: painting %q has no positive originalPrice", ErrArtworkPriceMissing, paintingID)
+	}
+
+	return &ArtworkPrice{ID: paintingID, PriceUSD: *doc.OriginalPrice}, nil
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -1605,6 +1605,90 @@ paths:
           description: Service Unavailable - pricing or Stripe is disabled
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
+  /purchases:charge:
+    post:
+      summary: Charge a buyer's purchase and open the on-chain escrow.
+      description: >-
+        Charges the buyer's purchase and opens the on-chain escrow with a
+        server-computed amount. The server reads the artwork price from Mongo
+        (editions.price or paintings.originalPrice, both required and in
+        dollars), applies the configured platform fee, converts the total to
+        FLOW via the Pyth oracle (rejecting prices older than the configured
+        max age), creates and confirms a Stripe PaymentIntent, opens the
+        escrow, and persists the audit record. No amount is trusted from the
+        client. One PaymentIntent funds at most one escrow. Retries are
+        governed by the `Idempotency-Key` header, which is propagated to
+        Stripe; replays return the stored result, while a conflicting duplicate
+        attempt returns 409.
+      operationId: createPurchaseCharge
+      x-required-scopes:
+        - studio.charge.create
+      tags:
+        - Studio
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - userId
+                - artworkKind
+                - artworkId
+                - stripeCustomerId
+                - buyer
+                - seller
+                - editionId
+                - chipId
+                - unlockAt
+                - nonce
+              properties:
+                userId:
+                  type: string
+                artworkKind:
+                  type: string
+                  enum: [edition, painting]
+                artworkId:
+                  type: string
+                stripeCustomerId:
+                  type: string
+                paymentMethodId:
+                  type: string
+                metadata:
+                  type: string
+                buyer:
+                  type: string
+                seller:
+                  type: string
+                editionId:
+                  type: integer
+                  format: uint64
+                chipId:
+                  type: string
+                unlockAt:
+                  type: number
+                  format: float
+                nonce:
+                  type: integer
+                  format: uint64
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad Request - malformed body
+        '404':
+          description: Not Found - artwork does not exist
+        '409':
+          description: Conflict - duplicate attempt for the same Idempotency-Key or already-recorded charge
+        '422':
+          description: Unprocessable Entity - artwork price is missing
+        '503':
+          description: Service Unavailable - pricing, Pyth oracle, Stripe or escrow is disabled
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
   /studio/charges:
     get:
       summary: List studio production charges for a user.


### PR DESCRIPTION
## Resumen

Nuevo endpoint `POST /purchases:charge` que cobra la compra del comprador y abre el escrow on-chain con un **monto calculado en el servidor** (misma disciplina que `/stock-requests:create`): no se confía ninguna cifra del cliente.

## Qué hace el flujo

1. Lee el precio de la obra desde Mongo (`editions.price` / `paintings.originalPrice`, ambos obligatorios y en dólares) — el cliente solo manda el id de la edición/pintura.
2. Aplica la comisión de plataforma (5%, configuración del servidor `PurchasePlatformFeeBasisPoints`, **no** `getPlatformFee()` que devuelve `0.0` a propósito).
3. Convierte el total a FLOW vía Pyth por HTTP (Hermes, feed FLOW/USD, gratis y sin llave); rechaza precios con más de `PythMaxAge` (60s) de antigüedad.
4. Crea y confirma el PaymentIntent de Stripe.
5. Abre el escrow con el monto FLOW calculado por el servidor.
6. Persiste el registro de auditoría (`purchase_charges`).

Un PaymentIntent financia como máximo un escrow. Retries gobernados por `Idempotency-Key` (propagado a Stripe); replays devuelven el resultado almacenado y un duplicado en conflicto devuelve 409.

## Cambios

- `artdrop/purchase/` — nuevo paquete: servicio, handler, cliente Pyth/Hermes, store GORM, migración `m20260821` (tabla `purchase_charges`).
- `datastore/mongo/purchase_store.go` — lectura de `editions.price` / `paintings.originalPrice`.
- `artdrop/plugin.go` — wiring de la ruta `/purchases:charge` + adaptador `purchaseEscrowCreator` (resuelve el ciclo de imports: `purchase` no importa `artdrop`).
- `configs/configs.go` — config de fee, envío, Pyth (base URL, feed id, max age).
- `openapi.yml` — entrada `/purchases:charge` con `x-required-scopes: [studio.charge.create]`.
- `artdrop/escrow_amount_validation_test.go` — se quita el `t.Skip` (el flujo de compra es quien ahora es dueño del monto).
- `artdrop/purchase/service_test.go` — tests happy path + errores, idempotencia, escrow.

## Verificación

- `go build ./...` ✅
- `go vet ./artdrop/... ./datastore/... ./configs/...` ✅
- `gofmt -l` limpio ✅
- `go test ./artdrop/... ./datastore/... ./configs/...` ✅
- `go test -run 'Auth|Route|Scope' .` ✅ (paridad ruta/scope — la ruta nueva tiene su `x-required-scopes`)

Closes #93